### PR TITLE
Fix: overwritten socket_id parameter in trigger

### DIFF
--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -206,14 +206,14 @@ class Pusher
 	*/
 	public function trigger( $channel, $event, $payload, $socket_id = null, $debug = false, $already_encoded = false )
 	{
-	  if ( $socket_id !== null )
+		$query_params = array();
+		
+	  	if ( $socket_id !== null )
 		{
 			$query_params['socket_id'] = $socket_id;
 		}
 	  
 		$s_url = $this->settings['url'] . '/channels/' . $channel . '/events';		
-
-		$query_params = array();
 		
 		$payload_encoded = $already_encoded ? $payload : json_encode( $payload );
 		$query_params['body_md5'] = md5( $payload_encoded );


### PR DESCRIPTION
The socket_id parameter in the trigger method was deleted and not 
properly sent back in the CURL request, thus excluding recipients was not 
working as intended.
