### PR TITLE
Improved the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "description" : "Library for interacting with the Pusher REST API",
     "keywords": ["php-pusher-server", "pusher", "rest", "realtime", "trigger", "publish", "events"],
     "homepage": "https://github.com/pusher/pusher-php-server",
+    "license": "MIT",
     "require": {
         "php": ">=5.2",
         "ext-curl": "*"


### PR DESCRIPTION
- Removed the explicit version, as recommended by Composer. It is
  ignored for branches in the VCS repository and is only a source of
  mistakes for tags as it would have to match the version guessed from
  the tag name to avoid being skipped by composer.
- Removed the useless dependency to composer/installers as the library
  is not using one of its custom types but the standard installer.
- Added the missing requirement to ext-curl as it is a required 
  dependency.
- Fixed the autoload configuration as this library does not follow 
  PSR-0 and so cannot be handled properly by the PSR-0 autoloader.
- Added the license key in the composer.json
