### PR TITLE
Add namespaces and update PHP support to 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,15 @@
     "homepage": "https://github.com/pusher/pusher-php-server",
     "license": "MIT",
     "require": {
-        "php": ">=5.2",
+        "php": ">=5.3.3",
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "~4.0"
     },
     "autoload": {
-        "classmap": [ "lib/" ]
+        "psr-4": {
+            "Pusher\\": "src/"
+        }
     }
 }

--- a/src/Exceptions/PusherException.php
+++ b/src/Exceptions/PusherException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Pusher\Exceptions;
+
+class PusherException extends Exception {}

--- a/src/PusherInstance.php
+++ b/src/PusherInstance.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Pusher;
+
+class PusherInstance
+{
+	private static $instance = null;
+	private static $app_id	= '';
+	private static $secret	= '';
+	private static $api_key = '';
+
+	private function __construct() { }
+	private function __clone() { }
+
+	public static function get_pusher()
+	{
+		if (self::$instance !== null) return self::$instance;
+
+		self::$instance = new Pusher(
+			self::$api_key,
+			self::$secret,
+			self::$app_id
+		);
+
+		return self::$instance;
+	}
+}

--- a/test/acceptance/channelQueryTest.php
+++ b/test/acceptance/channelQueryTest.php
@@ -1,5 +1,7 @@
 <?php
-	
+
+use Pusher\Pusher;
+
 	class PusherChannelQueryTest extends PHPUnit_Framework_TestCase
 	{
 
@@ -12,29 +14,29 @@
 		public function testChannelInfo()
 		{
 			$response = $this->pusher->get_channel_info('channel-test');
-			
+
 			//print_r( $response );
-			
+
 			$this->assertObjectHasAttribute('occupied', $response, 'class has occupied attribute');
 		}
-		
+
 		public function testChannelList()
 		{
 			$result = $this->pusher->get_channels();
 			$channels = $result->channels;
-			
+
 			 // print_r( $channels );
-			
+
 			foreach( $channels as $channel_name => $channel_info ) {
         echo( "channel_name: $channel_name\n");
         echo( 'channel_info: ' );
         print_r( $channel_info );
         echo( "\n\n");
       }
-			
+
 			$this->assertTrue( is_array($channels), 'channels is an array' );
 		}
-		
+
 		public function testFilterByPrefixNoChannels()
 		{
 			$options = array(
@@ -45,9 +47,9 @@
 // print_r( $result );
 
 		  $channels = $result->channels;
-		  
+
 		  // print_r( $channels );
-		  
+
 			$this->assertTrue( is_array($channels), 'channels is an array' );
 			$this->assertEquals( 0, count( $channels ), 'should be an empty array' );
 		}
@@ -62,9 +64,9 @@
 // print_r( $result );
 
 		  $channels = $result->channels;
-		  
+
 		  // print_r( $channels );
-		  
+
 			$this->assertEquals( 1, count( $channels ), 'channels have a single test-channel present. For this test to pass you must have your API Access setting open for the application you are testing against' );
 		}
 
@@ -76,7 +78,7 @@
 				'info' => 'user_count'
 			);
 		  $result = $this->pusher->get_channels( $options );
-		  
+
 			$this->assertFalse( $result, 'query should fail' );
 		}
 
@@ -119,10 +121,10 @@
 			$this->assertEquals( $response[ 'status' ], 200 );
 
 			$result = $response[ 'result' ];
-			
+
 			$this->assertArrayHasKey('occupied', $result, 'class has occupied attribute');
 		}
-		
+
 	}
 
 ?>

--- a/test/acceptance/triggerTest.php
+++ b/test/acceptance/triggerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Pusher\Pusher;
+
 	class PusherPushTest extends PHPUnit_Framework_TestCase
 	{
 
@@ -22,19 +24,19 @@
 		{
 			$this->assertNotNull($this->pusher, 'Created new Pusher object');
 		}
-		
+
 		public function testStringPush()
 		{
 			$string_trigger = $this->pusher->trigger('test_channel', 'my_event', 'Test string');
 			$this->assertTrue($string_trigger, 'Trigger with string payload');
 		}
-		
+
 		public function testArrayPush()
 		{
 			$structure_trigger = $this->pusher->trigger('test_channel', 'my_event', array( 'test' => 1 ));
 			$this->assertTrue($structure_trigger, 'Trigger with structured payload');
 		}
-		
+
 		public function testEncryptedPush()
 		{
 			$options = array(
@@ -43,7 +45,7 @@
 			);
 			$pusher = new Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, $options);
 			$pusher->set_logger( new TestLogger() );
-			
+
 			$structure_trigger = $pusher->trigger('test_channel', 'my_event', array( 'encrypted' => 1 ));
 			$this->assertTrue($structure_trigger, 'Trigger with over encrypted connection');
 		}
@@ -54,7 +56,7 @@
 			$response = $this->pusher->trigger('test_channel', 'my_event', $data, null, true );
 			$this->assertEquals( 413, $response[ 'status' ] , '413 HTTP status response expected');
 		}
-		
+
 		/**
      * @expectedException PusherException
      */
@@ -66,12 +68,12 @@
 			$data = array( 'event_name' => 'event_data' );
 			$response = $this->pusher->trigger( $channels, 'my_event', $data );
 		}
-		
+
 		public function test_triggering_event_on_multiple_channels() {
 			$data = array( 'event_name' => 'event_data' );
 			$channels = array( 'test_channel_1', 'test_channel_2' );
 			$response = $this->pusher->trigger( $channels, 'my_event', $data );
-		
+
 			$this->assertTrue( $response );
 		}
 	}

--- a/test/test_includes.php
+++ b/test/test_includes.php
@@ -14,6 +14,6 @@ else
   define('PUSHERAPP_HOST', 'http://api.pusherapp.com');
 }
 
-require_once($dir . '/../lib/Pusher.php');
+require_once($dir . '/../src/Pusher.php');
 
 require_once( $dir . '/TestLogger.php' );

--- a/test/unit/authQueryStringTest.php
+++ b/test/unit/authQueryStringTest.php
@@ -1,33 +1,35 @@
 <?php
-	
+
+use Pusher\Pusher;
+
 	class PusherAuthQueryString extends PHPUnit_Framework_TestCase
 	{
 
 		protected function setUp()
 		{
-			$this->pusher = new Pusher('thisisaauthkey', 'thisisasecret', 1, true); 
+			$this->pusher = new Pusher('thisisaauthkey', 'thisisasecret', 1, true);
 		}
-		
+
 		public function testArrayImplode()
 		{
 		  $val = array('testKey' => 'testValue');
-		  
+
 		  $expected = 'testKey=testValue';
 		  $actual = Pusher::array_implode( '=', '&', $val );
-		  
-		  $this->assertEquals($actual, 
+
+		  $this->assertEquals($actual,
 				$expected,
 				'auth signature valid');
 		}
-		
+
 		public function testArrayImplodeWithTwoValues()
 		{
 		  $val = array('testKey' => 'testValue', 'testKey2' => 'testValue2');
-		  
+
 		  $expected = 'testKey=testValue&testKey2=testValue2';
 		  $actual = Pusher::array_implode( '=', '&', $val );
-		  
-		  $this->assertEquals($actual, 
+
+		  $this->assertEquals($actual,
 				$expected,
 				'auth signature valid');
 		}
@@ -51,17 +53,17 @@
   		  $query_params,
   		  $auth_version,
   		  $time);
-  		  
+
   		$expected_to_sign = "POST\n$request_path\nauth_key=$auth_key&auth_timestamp=$time&auth_version=$auth_version&name=an_event";
   		$expected_auth_signature = hash_hmac( 'sha256', $expected_to_sign, $auth_secret, false );
   		$expected_query_string = "auth_key=$auth_key&auth_signature=$expected_auth_signature&auth_timestamp=$time&auth_version=$auth_version&name=an_event";
-			
-			
-			$this->assertEquals($auth_query_string, 
+
+
+			$this->assertEquals($auth_query_string,
 				$expected_query_string,
 				'auth signature valid');
 		}
-		
+
 	}
 
 ?>

--- a/test/unit/pusherConstructorTest.php
+++ b/test/unit/pusherConstructorTest.php
@@ -1,5 +1,7 @@
 <?php
-	
+
+use Pusher\Pusher;
+
 	class PusherConstructorTest extends PHPUnit_Framework_TestCase
 	{
 
@@ -24,11 +26,11 @@
 			$this->assertEquals( $scheme, $settings[ 'scheme' ] );
 			$this->assertEquals( $host, $settings[ 'host' ] );
 		}
-		
+
 		public function testLegacyHostParamWithNoSchemeCanBeUsedResultsInHostBeingUsedWithDefaultScheme() {
 			$host = 'test.com';
 			$pusher = new Pusher( 'app_key', 'app_secret', 'app_id', false, $host );
-			
+
 			$settings = $pusher->getSettings();
 			$this->assertEquals( $host, $settings[ 'host' ] );
 		}
@@ -37,7 +39,7 @@
 			$host = 'https://test.com';
 			$port = 90;
 			$pusher = new Pusher( 'app_key', 'app_secret', 'app_id', false, $host, $port );
-			
+
 			$settings = $pusher->getSettings();
 			$this->assertEquals( 'https', $settings[ 'scheme' ] );
 		}
@@ -60,17 +62,17 @@
 			$settings = $pusher->getSettings();
 			$this->assertEquals( $timeout, $settings[ 'timeout' ] );
 		}
-		
+
 		public function testEncryptedOptionWillSetHostAndPort() {
 			$options = array( 'encrypted' => true );
 			$pusher = new Pusher( 'app_key', 'app_secret', 'app_id', $options );
-			
+
 			$settings = $pusher->getSettings();
 			$this->assertEquals( 'https', $settings[ 'scheme' ], 'https' );
 			$this->assertEquals( 'api.pusherapp.com', $settings[ 'host' ] );
 			$this->assertEquals( '443', $settings[ 'port' ] );
 		}
-		
+
 		public function testEncryptedOptionWillBeOverwrittenByHostAndPortOptionsSetHostAndPort() {
 			$options = array(
 				'encrytped' => true,
@@ -78,22 +80,22 @@
 				'port' => '3000'
 			);
 			$pusher = new Pusher( 'app_key', 'app_secret', 'app_id', $options );
-			
+
 			$settings = $pusher->getSettings();
 			$this->assertEquals( 'http', $settings[ 'scheme' ] );
 			$this->assertEquals( $options[ 'host' ], $settings[ 'host' ] );
 			$this->assertEquals( $options[ 'port' ], $settings[ 'port' ] );
-		}	
-		
+		}
+
 		public function testSchemeIsStrippedAndIgnoredFromHostInOptions() {
 			$options = array(
 				'host' => 'https://test.com'
 			);
 			$pusher = new Pusher( 'app_key', 'app_secret', 'app_id', $options );
-			
+
 			$settings = $pusher->getSettings();
 			$this->assertEquals( 'http', $settings[ 'scheme' ] );
 			$this->assertEquals( 'test.com', $settings[ 'host' ] );
-		}		
+		}
 
 	}

--- a/test/unit/socketAuthTest.php
+++ b/test/unit/socketAuthTest.php
@@ -1,11 +1,13 @@
 <?php
-	
+
+use Pusher\Pusher;
+
 	class PusherSocketAuthTest extends PHPUnit_Framework_TestCase
 	{
 
 		protected function setUp()
 		{
-			$this->pusher = new Pusher('thisisaauthkey', 'thisisasecret', 1, true); 
+			$this->pusher = new Pusher('thisisaauthkey', 'thisisasecret', 1, true);
 		}
 
 		public function testObjectConstruct()
@@ -16,11 +18,11 @@
 		public function testSocketAuthKey()
 		{
 			$socket_auth = $this->pusher->socket_auth('testing_pusher-php', 'testing_socket_auth');
-			$this->assertEquals($socket_auth, 
+			$this->assertEquals($socket_auth,
 				'{"auth":"thisisaauthkey:ee548cf60217ed18281da39a8eb23609105f1bde29372650cb67bd91c284aae1"}',
 				'Socket auth key valid');
 		}
-		
+
 	}
 
 ?>


### PR DESCRIPTION
Adding namespaces for better usage within modern PHP applications. The current setup creates a global class `Pusher` that is injected everywhere with composers autoloader. This could cause problems for developers who want to use the Pusher package but only wants to inject it within their custom modules. 

Instead I've added namespaces and PSR-4 style autoloader. I'll describe it more below.

What is new:
- Added the namespace `Pusher`. To fetch the `Pusher` object we now have to included it at the top of the document.
```php
<?php

namespace Acme\Services;

use Pusher\Pusher;

class PusherManager
{
	function __construct()
	{
		$this->pusher = new Pusher();
	}
}
```

- Removed support for PHP version 5.2. Namespaces was added in version `5.3`. Therefore, version `5.2` can't be supported.
- Separated the classes into multiple files. The `Pusher`, `PusherInstance` and `PusherException` now have their own files. 


What do you guys think? I know this is a major change. As I've read in #8 some of the new updates were used in another unofficial repository instead. This update is not as big. It just adds a new way of loading the classes. Hope you guys like it. Thanks.