### PR TITLE
Update PHPUnit to the maintained versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "~4"
     },
     "autoload": {
         "classmap": [ "lib/" ]


### PR DESCRIPTION
PHPUnit 3.7 is very old and not maintained anymore. The current stable version is 4.5