### PR TITLE
Validate socket_id and channel names

### DIFF
--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -184,6 +184,16 @@ class Pusher
 		}
 
 	}
+
+	/**
+	 * Ensure a socket_id is valid based on our spec
+	 */
+	private function validate_socket_id( $socket_id )
+	{
+		if ( ! preg_match( '/\A\d+\.\d+\z/', $socket_id ) ) {
+			throw new PusherException( 'Invalid socket ID ' . $socket_id );
+		}
+	}
 	
 	/**
 	 * Utility function used to create the curl object with common settings
@@ -330,6 +340,7 @@ class Pusher
 
 		if ( $socket_id !== null )
 		{
+			$this->validate_socket_id( $socket_id );
 			$post_params[ 'socket_id' ] = $socket_id;
 		}
 
@@ -445,6 +456,8 @@ class Pusher
 	 */
 	public function socket_auth( $channel, $socket_id, $custom_data = false )
 	{
+		$this->validate_socket_id( $socket_id );
+
 		if($custom_data == true)
 		{
 			$signature = hash_hmac( 'sha256', $socket_id . ':' . $channel . ':' . $custom_data, $this->settings['secret'], false );

--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -186,6 +186,16 @@ class Pusher
 	}
 
 	/**
+	 * Ensure a channel name is valid based on our spec
+	 */
+	private function validate_channel( $channel )
+	{
+		if ( ! preg_match( '/\A[-a-zA-Z0-9_=@,.;]+\z/', $channel ) ) {
+			throw new PusherException( 'Invalid channel name ' . $channel );
+		}
+	}
+
+	/**
 	 * Ensure a socket_id is valid based on our spec
 	 */
 	private function validate_socket_id( $socket_id )
@@ -327,6 +337,8 @@ class Pusher
 			throw new PusherException('An event can be triggered on a maximum of 100 channels in a single call.');
 		}
 
+		array_walk( $channels, array( $this, 'validate_channel' ) );
+
 		$query_params = array();
 		
 		$s_url = $this->settings['base_path'] . '/events';		
@@ -456,6 +468,7 @@ class Pusher
 	 */
 	public function socket_auth( $channel, $socket_id, $custom_data = false )
 	{
+		$this->validate_channel( $channel );
 		$this->validate_socket_id( $socket_id );
 
 		if($custom_data == true)

--- a/test/unit/socketAuthTest.php
+++ b/test/unit/socketAuthTest.php
@@ -21,12 +21,76 @@
 				'Socket auth key valid');
 		}
 
+		public function testComplexSocketAuthKey()
+		{
+			$socket_auth = $this->pusher->socket_auth('-azAZ9_=@,.;', '45055.28877557');
+			$this->assertEquals($socket_auth,
+				'{"auth":"thisisaauthkey:d1c20ad7684c172271f92c108e11b45aef07499b005796ae1ec5beb924f361c4"}',
+				'Socket auth key valid');
+		}
+
 		/**
 		 * @expectedException PusherException
 		 */
-		public function testInvalidSocketThrowsException()
+		public function testTrailingColonSocketIDThrowsException()
 		{
-			$this->pusher->socket_auth('testing_pusher-php', 'invalid');
+			$this->pusher->socket_auth('testing_pusher-php', '1.1:');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonSocketIDThrowsException()
+		{
+			$this->pusher->socket_auth('testing_pusher-php', ':1.1');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonNLSocketIDThrowsException()
+		{
+			$this->pusher->socket_auth('testing_pusher-php', ':\n1.1');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonNLSocketIDThrowsException()
+		{
+			$this->pusher->socket_auth('testing_pusher-php', '1.1\n:');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonChannelThrowsException()
+		{
+			$this->pusher->socket_auth('test_channel:', '1.1');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonChannelThrowsException()
+		{
+			$this->pusher->socket_auth(':test_channel', '1.1');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonNLChannelThrowsException()
+		{
+			$this->pusher->socket_auth(':\ntest_channel', '1.1');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonNLChannelThrowsException()
+		{
+			$this->pusher->socket_auth('test_channel\n:', '1.1');
 		}
 	}
 

--- a/test/unit/socketAuthTest.php
+++ b/test/unit/socketAuthTest.php
@@ -15,12 +15,19 @@
 
 		public function testSocketAuthKey()
 		{
-			$socket_auth = $this->pusher->socket_auth('testing_pusher-php', 'testing_socket_auth');
+			$socket_auth = $this->pusher->socket_auth('testing_pusher-php', '1.1');
 			$this->assertEquals($socket_auth, 
-				'{"auth":"thisisaauthkey:ee548cf60217ed18281da39a8eb23609105f1bde29372650cb67bd91c284aae1"}',
+				'{"auth":"thisisaauthkey:751ccc12aeaa79d46f7c199bced5fa47527d3480b51fe61a0bd10438241bd52d"}',
 				'Socket auth key valid');
 		}
-		
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testInvalidSocketThrowsException()
+		{
+			$this->pusher->socket_auth('testing_pusher-php', 'invalid');
+		}
 	}
 
 ?>


### PR DESCRIPTION
Validate socket_id is a series of numbers followed by a dot followed by more numbers
when generating the authentication signature and triggering messages.

@DanielWaterworth 