### PR TITLE
Validate channel name & socket_id values

### DIFF
--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -211,7 +211,7 @@ class Pusher
 	 */
 	private function validate_socket_id( $socket_id )
 	{
-		if ( $socket_id && !preg_match( '/\A\d+\.\d+\z/', $socket_id ) ) {
+		if ( $socket_id !== null && !preg_match( '/\A\d+\.\d+\z/', $socket_id ) ) {
 			throw new PusherException( 'Invalid socket ID ' . $socket_id );
 		}
 	}

--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -191,9 +191,9 @@ class Pusher
 	private function validate_channels($channels) {
 		if( count( $channels ) > 100 ) {
 			throw new PusherException('An event can be triggered on a maximum of 100 channels in a single call.');
-			
-			array_walk( $channels, array( $this, 'validate_channel' ) );
 		}
+		
+		array_walk( $channels, array( $this, 'validate_channel' ) );
 	}
 
 	/**

--- a/test/unit/channelInfoUnitTest.php
+++ b/test/unit/channelInfoUnitTest.php
@@ -1,0 +1,43 @@
+<?php
+	
+	class PusherChannelInfoUnitTest extends PHPUnit_Framework_TestCase
+	{
+
+		protected function setUp()
+		{
+			$this->pusher = new Pusher('thisisaauthkey', 'thisisasecret', 1, true); 
+		}
+    
+    /**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonChannelThrowsException()
+		{
+			$this->pusher->get_channel_info('test_channel:');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonChannelThrowsException()
+		{
+			$this->pusher->get_channel_info(':test_channel');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonNLChannelThrowsException()
+		{
+			$this->pusher->get_channel_info(':\ntest_channel');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonNLChannelThrowsException()
+		{
+			$this->pusher->get_channel_info('test_channel\n:');
+		}
+    
+  }

--- a/test/unit/socketAuthTest.php
+++ b/test/unit/socketAuthTest.php
@@ -15,12 +15,83 @@
 
 		public function testSocketAuthKey()
 		{
-			$socket_auth = $this->pusher->socket_auth('testing_pusher-php', 'testing_socket_auth');
+			$socket_auth = $this->pusher->socket_auth('testing_pusher-php', '1.1');
 			$this->assertEquals($socket_auth, 
-				'{"auth":"thisisaauthkey:ee548cf60217ed18281da39a8eb23609105f1bde29372650cb67bd91c284aae1"}',
+				'{"auth":"thisisaauthkey:751ccc12aeaa79d46f7c199bced5fa47527d3480b51fe61a0bd10438241bd52d"}',
 				'Socket auth key valid');
 		}
-		
+
+		public function testComplexSocketAuthKey()
+		{
+			$socket_auth = $this->pusher->socket_auth('-azAZ9_=@,.;', '45055.28877557');
+			$this->assertEquals($socket_auth,
+				'{"auth":"thisisaauthkey:d1c20ad7684c172271f92c108e11b45aef07499b005796ae1ec5beb924f361c4"}',
+				'Socket auth key valid');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonSocketIDThrowsException()
+		{
+			$this->pusher->socket_auth('testing_pusher-php', '1.1:');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonSocketIDThrowsException()
+		{
+			$this->pusher->socket_auth('testing_pusher-php', ':1.1');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonNLSocketIDThrowsException()
+		{
+			$this->pusher->socket_auth('testing_pusher-php', ':\n1.1');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonNLSocketIDThrowsException()
+		{
+			$this->pusher->socket_auth('testing_pusher-php', '1.1\n:');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonChannelThrowsException()
+		{
+			$this->pusher->socket_auth('test_channel:', '1.1');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonChannelThrowsException()
+		{
+			$this->pusher->socket_auth(':test_channel', '1.1');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonNLChannelThrowsException()
+		{
+			$this->pusher->socket_auth(':\ntest_channel', '1.1');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonNLChannelThrowsException()
+		{
+			$this->pusher->socket_auth('test_channel\n:', '1.1');
+		}
 	}
 
 ?>

--- a/test/unit/triggerUnitTest.php
+++ b/test/unit/triggerUnitTest.php
@@ -81,5 +81,28 @@
 		{
 			$this->pusher->trigger('test_channel:', $this->eventName, $this->data, '1.1\n:');
 		}
+
+		public function testNullSocketID()
+		{
+			// Check this does not throw an exception
+			$this->pusher->trigger('test_channel', $this->eventName, $this->data, null);
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testFalseSocketIDThrowsException()
+		{
+			$this->pusher->trigger('test_channel', $this->eventName, $this->data, false);
+
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testEmptyStrSocketIDThrowsException()
+		{
+			$this->pusher->trigger('test_channel', $this->eventName, $this->data, "");
+		}
     
   }

--- a/test/unit/triggerUnitTest.php
+++ b/test/unit/triggerUnitTest.php
@@ -47,7 +47,39 @@
 		*/
 		public function testChannelArrayThrowsException()
 		{
-			$this->pusher->trigger(['this_one_is_okay', 'test_channel\n:'], $this->eventName, $this->data);
+			$this->pusher->trigger(array('this_one_is_okay', 'test_channel\n:'), $this->eventName, $this->data);
+		}
+		
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonSocketIDThrowsException()
+		{
+			$this->pusher->trigger('test_channel:', $this->eventName, $this->data, '1.1:');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonSocketIDThrowsException()
+		{
+			$this->pusher->trigger('test_channel:', $this->eventName, $this->data, ':1.1');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonNLSocketIDThrowsException()
+		{
+			$this->pusher->trigger('test_channel:', $this->eventName, $this->data, ':\n1.1');
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonNLSocketIDThrowsException()
+		{
+			$this->pusher->trigger('test_channel:', $this->eventName, $this->data, '1.1\n:');
 		}
     
   }

--- a/test/unit/triggerUnitTest.php
+++ b/test/unit/triggerUnitTest.php
@@ -1,0 +1,53 @@
+<?php
+	
+	class PusherTriggerUnitTest extends PHPUnit_Framework_TestCase
+	{
+
+		protected function setUp()
+		{
+			$this->pusher = new Pusher('thisisaauthkey', 'thisisasecret', 1, true);
+			$this->eventName = 'test_event';
+			$this->data = array();
+		}
+    
+    /**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonChannelThrowsException()
+		{
+			$this->pusher->trigger('test_channel:', $this->eventName, $this->data);
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonChannelThrowsException()
+		{
+			$this->pusher->trigger(':test_channel', $this->eventName, $this->data);
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testLeadingColonNLChannelThrowsException()
+		{
+			$this->pusher->trigger(':\ntest_channel', $this->eventName, $this->data);
+		}
+
+		/**
+		 * @expectedException PusherException
+		 */
+		public function testTrailingColonNLChannelThrowsException()
+		{
+			$this->pusher->trigger('test_channel\n:', $this->eventName, $this->data);
+		}
+		
+		/**
+		* @expectedException PusherException
+		*/
+		public function testChannelArrayThrowsException()
+		{
+			$this->pusher->trigger(['this_one_is_okay', 'test_channel\n:'], $this->eventName, $this->data);
+		}
+    
+  }


### PR DESCRIPTION
Validate socket_id when generating signatures and triggering messages
Validate socket_id is a series of numbers followed by a dot followed by more numbers
when generating the authentication signature and triggering messages.