### PR TITLE
Update readme to explain that a client must be connected during tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ Requires [phpunit](https://github.com/sebastianbergmann/phpunit/).
 
 * Got to the `tests` directory
 * Rename `config.example.php` and replace the values with valid Pusher credentials **or** create environment variables.
+* Some tests require a client to be connected to the app you defined in the config;
+  you can do this by opening https://app.pusher.com/apps/<YOUR_TEST_APP_ID>/api_access in the browser
 * Execute `phpunit .` to run all the tests.
 
 ## Framework Integrations


### PR DESCRIPTION
@leggetter what do you think? I didn't know I had to do this at first, and it wasn't clear from the error messages.