### PR TITLE
Avoid reference mismatch when validating channels

### DIFF
--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -192,8 +192,8 @@ class Pusher
 		if( count( $channels ) > 100 ) {
 			throw new PusherException('An event can be triggered on a maximum of 100 channels in a single call.');
 		}
-		
-		array_walk( $channels, array( $this, 'validate_channel' ) );
+
+		array_map( array( $this, 'validate_channel' ), $channels );
 	}
 
 	/**


### PR DESCRIPTION
array_walk takes its argument by reference and calls the callback with a reference. This caused 2 different reference mismatches in the validation logic.

See http://jpauli.github.io/2014/06/27/references-mismatch.html for the explanation of what reference mismatches are