### PR TITLE
Update array_walk to a foreach loop when validating channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 2.2.2 (2015-05-15)
+
+[FIXED] Fixed a PHP 5.2 incompatibility caused by referencing a private method in array_walk.
+
 ## 2.2.1 (2015-05-13)
 
 [FIXED] Channel name and socket_id values are now validated.
+[BROKE] Inadvertently broke PHP 5.2 compatibility by referencing a private method in array_walk.
 
 ## 2.2.0 (2015-01-20)
 

--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -50,7 +50,7 @@ class PusherInstance {
 
 class Pusher
 {
-	public static $VERSION = '2.2.1';
+	public static $VERSION = '2.2.2';
 
 	private $settings = array(
 		'scheme' => 'http',
@@ -192,8 +192,10 @@ class Pusher
 		if( count( $channels ) > 100 ) {
 			throw new PusherException('An event can be triggered on a maximum of 100 channels in a single call.');
 		}
-		
-		array_walk( $channels, array( $this, 'validate_channel' ) );
+
+		foreach ($channels as $channel) {
+			$this->validate_channel($channel);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Referencing a private method in array_walk is incompatible with PHP 5.2

@leggetter @mdpye 