### PR TITLE
Added branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,11 @@
         "psr-4": {
             "pusher\\Tests\\": "tests/"
         }
-    }
+    },
+
+    "extra": {
+        "branch-alias": {
+            "dev-new-lib": "3.0-dev"
+        }
+    },
 }

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,5 @@
         "branch-alias": {
             "dev-new-lib": "3.0-dev"
         }
-    },
+    }
 }


### PR DESCRIPTION
It's usually a bad idea for people to install packages using a branch name. Instead they should be able to get the correct version by using any valid version constraint.