### PR TITLE
More testing for new-lib

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -93,7 +93,7 @@ class Pusher
         $channels = (array)$channels;
 
         if (count($channels) > 10) {
-            throw new PusherException('An event can be triggered on a maximum of 10 channels in a single call.');
+            throw new Exception\Exception('An event can be triggered on a maximum of 10 channels in a single call.');
         }
 
         $data = json_encode($data);
@@ -150,13 +150,5 @@ class Pusher
     public function presenceUsers($channel_name, $params = array())
     {
         return $this->client->get("/channels/$channel_name/users", $params);
-    }
-
-    /**
-     * @return boolean true if the channel is a presence channel.
-     */
-    private function isPresence($channel_name)
-    {
-        return strncmp("presence-", $channel_name, 0) == 0;
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Pusher\Tests;
+
+use Pusher\Client;
+
+class ClientTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testConstrcutor()
+    {
+        $c = new Client(array(
+            'base_url' => 'http://a:b@foobar.com',
+        ));
+        $this->assertEquals('http://foobar.com', $c->baseUrl);
+        $this->assertInstanceOf('Pusher\HTTPAdapter', $c->adapter);
+        $this->assertEquals(5, $c->timeout);
+        $this->assertNull($c->proxyUrl);
+        $this->assertInstanceOf('Pusher\KeyPair', $c->keyPair);
+    }
+
+    public function testRequest()
+    {
+        $c = new Client(array(
+            'base_url' => 'http://a:b@foobar.com',
+        ));
+        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $c->adapter
+            ->expects($this->once())
+            ->method('request')
+            ->will($this->returnValue(array('status' => 200, 'body' => '{"data":"A Pusher message"}')));
+        $result = $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+        $this->assertInstanceOf('\stdClass', $result);
+        $this->assertEquals('A Pusher message', $result->data);
+
+        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $c->adapter
+            ->expects($this->once())
+            ->method('request')
+            ->will($this->returnValue(array('status' => 202)));
+        $result = $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @expectedException \Pusher\Exception\HTTPError
+     * @expectedExceptionMessage Bad request
+     */
+    public function testRequest400Error()
+    {
+        $c = new Client(array(
+            'base_url' => 'http://a:b@foobar.com',
+        ));
+        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $c->adapter
+            ->expects($this->once())
+            ->method('request')
+            ->will($this->returnValue(array('status' => 400)));
+        $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+    }
+
+    /**
+     * @expectedException \Pusher\Exception\HTTPError
+     * @expectedExceptionMessage Authentication error
+     */
+    public function testRequest401Error()
+    {
+        $c = new Client(array(
+            'base_url' => 'http://a:b@foobar.com',
+        ));
+        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $c->adapter
+            ->expects($this->once())
+            ->method('request')
+            ->will($this->returnValue(array('status' => 401)));
+        $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+    }
+
+    /**
+     * @expectedException \Pusher\Exception\HTTPError
+     * @expectedExceptionMessage Not Found
+     */
+    public function testRequest404Error()
+    {
+        $c = new Client(array(
+            'base_url' => 'http://a:b@foobar.com',
+        ));
+        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $c->adapter
+            ->expects($this->once())
+            ->method('request')
+            ->will($this->returnValue(array('status' => 404)));
+        $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+    }
+
+    /**
+     * @expectedException \Pusher\Exception\HTTPError
+     * @expectedExceptionMessage Proxy Authentication Required
+     */
+    public function testRequest407Error()
+    {
+        $c = new Client(array(
+            'base_url' => 'http://a:b@foobar.com',
+        ));
+        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $c->adapter
+            ->expects($this->once())
+            ->method('request')
+            ->will($this->returnValue(array('status' => 407)));
+        $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+    }
+
+    /**
+     * @expectedException \Pusher\Exception\HTTPError
+     * @expectedExceptionMessage Unknown error
+     */
+    public function testRequestUnknownError()
+    {
+        $c = new Client(array(
+            'base_url' => 'http://a:b@foobar.com',
+        ));
+        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $c->adapter
+            ->expects($this->once())
+            ->method('request')
+            ->will($this->returnValue(array('status' => 500)));
+        $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+    }
+
+    public function testGetRequest()
+    {
+        $c = new Client(array(
+            'base_url' => 'http://a:b@foobar.com',
+        ));
+        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $c->adapter
+            ->expects($this->once())
+            ->method('request')
+            ->will($this->returnValue(array('status' => 200, 'body' => '{"data":"A Pusher message"}')));
+        $result = $c->get('/foo/bar', array('bill' => 'ben'));
+        $this->assertInstanceOf('\stdClass', $result);
+        $this->assertEquals('A Pusher message', $result->data);
+    }
+
+    public function testPostRequest()
+    {
+        $c = new Client(array(
+            'base_url' => 'http://a:b@foobar.com',
+        ));
+        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $c->adapter
+            ->expects($this->once())
+            ->method('request')
+            ->will($this->returnValue(array('status' => 200, 'body' => '{"data":"A Pusher message"}')));
+        $result = $c->post('/foo/bar', array('bill' => 'ben'));
+        $this->assertInstanceOf('\stdClass', $result);
+        $this->assertEquals('A Pusher message', $result->data);
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -34,7 +34,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Pusher\Exception\ConfigurationError
      */
-    public function testMissingKeysValidationError() {
+    public function testMissingKeysValidationError()
+    {
         $c = new Config(array(
             'base_url' => 'http://foobar.com',
         ));
@@ -44,7 +45,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Pusher\Exception\ConfigurationError
      */
-    public function testMissingAdapterError() {
+    public function testMissingAdapterError()
+    {
         $c = new Config(array(
             'base_url' => 'http://a:b@foobar.com',
         ));
@@ -55,7 +57,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Pusher\Exception\ConfigurationError
      */
-    public function testTimeoutConfigError() {
+    public function testTimeoutConfigError()
+    {
         $c = new Config(array(
             'base_url' => 'http://a:b@foobar.com',
             'adapter' => new \Pusher\FileAdapter(),
@@ -88,7 +91,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('d', $c->keyPair('c')->secret);
     }
 
-    public function testInstanceWithProxy() {
+    public function testInstanceWithProxy()
+    {
         $c = new Config(array(
             'base_url' => 'http://a:b@foobar.com',
             'proxy_url' => 'http://myproxy.com',
@@ -97,7 +101,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://myproxy.com', $c->proxyUrl);
     }
 
-    public function testWithAdapterOption() {
+    public function testWithAdapterOption()
+    {
         $c = new Config(array(
             'base_url' => 'http://a:b@foobar.com',
             'adapter' => new \Pusher\FileAdapter(),
@@ -106,7 +111,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Pusher\FileAdapter', $c->adapter);
     }
 
-    public function testSetBaseUrl() {
+    public function testSetBaseUrl()
+    {
         $c = new Config(array(
             'base_url' => 'http://a:b@foobar.com',
         ));

--- a/tests/CurlAdapterTest.php
+++ b/tests/CurlAdapterTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Pusher\Tests;
+
+use Pusher\CurlAdapter;
+
+class CurlAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsSupported()
+    {
+        $this->assertTrue(CurlAdapter::isSupported());
+    }
+
+    public function testRequest()
+    {
+        $Adapter = new CurlAdapter(array(CURLOPT_TIMEOUT => 30));
+
+        $result = $Adapter->request(
+            'GET',
+            'https://pusher.com',
+            array(
+                'User-Agent: pusher-php-test',
+                'Accept: text/html',
+                'Connection: keep-alive',
+            ),
+            null,
+            10,
+            null
+        );
+        $this->assertEquals(200, $result['status']);
+
+        $result = $Adapter->request(
+            'POST',
+            'https://pusher.com',
+            array(
+                'User-Agent: pusher-php-test',
+                'Accept: text/html',
+                'Connection: keep-alive',
+            ),
+            array('foo' => 'bar'),
+            10,
+            null
+        );
+        $this->assertEquals(404, $result['status']);
+        $this->assertContains('This ain\'t what you were looking for', $result['body']);
+
+        unset($Adapter);
+    }
+}

--- a/tests/CurlAdapterTest.php
+++ b/tests/CurlAdapterTest.php
@@ -6,6 +6,14 @@ use Pusher\CurlAdapter;
 
 class CurlAdapterTest extends \PHPUnit_Framework_TestCase
 {
+
+    public function setUp()
+    {
+        if (!extension_loaded('curl')) {
+            $this->markTestSkipped();
+        }
+    }
+
     public function testIsSupported()
     {
         $this->assertTrue(CurlAdapter::isSupported());

--- a/tests/FileAdapterTest.php
+++ b/tests/FileAdapterTest.php
@@ -6,6 +6,14 @@ use Pusher\FileAdapter;
 
 class FileAdapterTest extends \PHPUnit_Framework_TestCase
 {
+
+    public function setUp()
+    {
+        if (getenv('TRAVIS')) {
+            $this->markTestSkipped();
+        }
+    }
+
     public function testIsSupported()
     {
         $this->assertTrue(FileAdapter::isSupported());
@@ -13,7 +21,9 @@ class FileAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testRequest()
     {
-        $Adapter = new FileAdapter(array('http' => array('timeout' => 30)));
+        $Adapter = new FileAdapter(array(
+            'http' => array('timeout' => 30),
+        ));
         $result = $Adapter->request(
             'GET',
             'https://pusher.com',

--- a/tests/FileAdapterTest.php
+++ b/tests/FileAdapterTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Pusher\Tests;
+
+use Pusher\FileAdapter;
+
+class FileAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsSupported()
+    {
+        $this->assertTrue(FileAdapter::isSupported());
+    }
+
+    public function testRequest()
+    {
+        $Adapter = new FileAdapter(array('http' => array('timeout' => 30)));
+        $result = $Adapter->request(
+            'GET',
+            'https://pusher.com',
+            array(
+                'User-Agent: pusher-php-test',
+                'Accept: text/html',
+                'Connection: keep-alive',
+            ),
+            null,
+            10,
+            null
+        );
+        $this->assertEquals(200, $result['status']);
+
+        $result = $Adapter->request(
+            'POST',
+            'https://pusher.com',
+            array(
+                'User-Agent: pusher-php-test',
+                'Accept: text/html',
+                'Connection: keep-alive',
+            ),
+            array('foo' => 'bar'),
+            10,
+            null
+        );
+        $this->assertEquals(404, $result['status']);
+        $this->assertContains('This ain\'t what you were looking for', $result['body']);
+    }
+
+    public function testAdapterId()
+    {
+        $Adapter = new FileAdapter();
+        $this->assertEquals('file/0.0.0', $Adapter->adapterId());
+    }
+}

--- a/tests/PusherTest.php
+++ b/tests/PusherTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Pusher\Tests;
+
+use Pusher\Pusher;
+
+class PusherTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testConstructor()
+    {
+        $Pusher = new Pusher('http://a:b@foobar.com');
+
+        $this->assertInstanceOf('Pusher\Config', $Pusher->config);
+        $this->assertInstanceOf('Pusher\Client', $Pusher->client);
+    }
+
+    public function testKeyPair()
+    {
+        $Pusher = new Pusher('http://a:b@foobar.com');
+
+        $this->assertInstanceOf('Pusher\KeyPair', $Pusher->keyPair());
+    }
+
+    public function testAuthenticate()
+    {
+        $Pusher = new Pusher('http://a:b@foobar.com');
+        $this->assertEquals(
+            '{"auth":"a:a9e583c6fad5e38b69465bcff22fd809aac8b95fbdb9f7cae4bb27cb8e512f88"}',
+            $Pusher->authenticate('38087.11062758', 'private-messages')
+        );
+
+        $this->assertEquals(
+            '{"auth":"a:8c30292debfdfdbc169bc7866a979936c886ea9fd70eb397f1facd55da5e3d2a","channel_data":"\"channel-data\""}',
+            $Pusher->authenticate('38087.11062758', 'private-messages', 'channel-data')
+        );
+    }
+
+    public function testWebhook()
+    {
+        $_SERVER = array(
+            'HTTP_X_PUSHER_KEY' => 'a',
+            'HTTP_X_PUSHER_SIGNATURE' => 'sdfkjq2jnk12je',
+        );
+
+        $Pusher = new Pusher('http://a:b@foobar.com');
+        $result = $Pusher->webhook(null, __DIR__ . '/body1.txt');
+
+        $this->assertInstanceOf('Pusher\WebHook', $result);
+        $this->assertEquals('sdfkjq2jnk12je', $result->signature);
+        $this->assertInstanceOf('Pusher\KeyPair', $result->keyPair);
+
+        unset($_SERVER);
+    }
+
+    public function testTrigger()
+    {
+        $Pusher = new Pusher('http://a:b@foobar.com');
+
+        $Pusher->client = $this->getMock('Pusher\Client', array('post'), array('http://a:b@foobar.com'));
+        $Pusher->client
+            ->expects($this->exactly(2))
+            ->method('post')
+            ->withConsecutive(
+                array(
+                    $this->equalTo('events'),
+                    $this->equalTo(
+                        array(
+                            'name' => 'new-message',
+                            'data' => '{"body":"Hello"}',
+                            'channels' => array('my-message'),
+                        )
+                    ),
+                ),
+                array(
+                    $this->equalTo('events'),
+                    $this->equalTo(
+                        array(
+                            'name' => 'new-message',
+                            'data' => '{"body":"Hello"}',
+                            'channels' => array('my-message'),
+                            'socket_id' => '12345',
+                        )
+                    ),
+                )
+
+            );
+
+        $Pusher->trigger('my-message', 'new-message', array('body' => 'Hello'));
+        $Pusher->trigger('my-message', 'new-message', array('body' => 'Hello'), '12345');
+    }
+
+    /**
+     * @expectedException \Pusher\Exception\Exception
+     * @expectedExceptionMessage An event can be triggered on a maximum of 10 channels in a single call.
+     */
+    public function testTriggerThrowsError()
+    {
+        $Pusher = new Pusher('http://a:b@foobar.com');
+        $Pusher->trigger(
+            array(
+                'my-message1',
+                'my-message2',
+                'my-message3',
+                'my-message4',
+                'my-message5',
+                'my-message6',
+                'my-message7',
+                'my-message8',
+                'my-message9',
+                'my-message10',
+                'my-message11',
+            ),
+            'new-message',
+            array('body' => 'Hello')
+        );
+    }
+
+    public function testChannels()
+    {
+        $Pusher = new Pusher('http://a:b@foobar.com');
+        $Pusher->client = $this->getMock('Pusher\Client', array('get'), array('http://a:b@foobar.com'));
+        $Pusher->client
+            ->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/channels'),
+                $this->equalTo(array('bill' => 'ben'))
+            );
+        $Pusher->channels(array('bill' => 'ben'));
+    }
+
+    public function testChannelInfo()
+    {
+        $Pusher = new Pusher('http://a:b@foobar.com');
+        $Pusher->client = $this->getMock('Pusher\Client', array('get'), array('http://a:b@foobar.com'));
+        $Pusher->client
+            ->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/channels/foo'),
+                $this->equalTo(array('bill' => 'ben'))
+            );
+        $Pusher->channelInfo('foo', array('bill' => 'ben'));
+    }
+
+    public function testPresenceUsers()
+    {
+        $Pusher = new Pusher('http://a:b@foobar.com');
+        $Pusher->client = $this->getMock('Pusher\Client', array('get'), array('http://a:b@foobar.com'));
+        $Pusher->client
+            ->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('/channels/foo/users'),
+                $this->equalTo(array('bill' => 'ben'))
+            );
+        $Pusher->presenceUsers('foo', array('bill' => 'ben'));
+    }
+}

--- a/tests/WebHookTest.php
+++ b/tests/WebHookTest.php
@@ -26,5 +26,9 @@ class WebHookTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($body, $wh->body);
         $this->assertEquals(1, count($wh->events()));
         $this->assertEquals(1404402287, $wh->timestamp());
+
+        $wh->keyPair = null;
+        $wh->signature = null;
+        $this->assertFalse($wh->valid());
     }
 }


### PR DESCRIPTION
Hi,

Here are some more tests to cover the core classes. There's still some improvements to be made - I haven't covered the exception classes and the HTTPAdapter tests need some work.

My suggestions going forward would be to refactor the adapter classes slightly to make them a bit easier to test. Secondly, all the requests to the Pusher API have been mocked - it's probably a good idea to get a test app key/secret so that some integration tests can be written.

This at least takes the unit test coverage to ~95%. Hope this helps.