### PR TITLE
Updates to the library constructor - #66

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -39,7 +39,6 @@ class Client
      */
     public function __construct($config)
     {
-        $config = Config::ensure($config);
         $this->baseUrl = $config->baseUrl;
         $this->adapter = $config->adapter;
         $this->timeout = $config->timeout;

--- a/src/Config.php
+++ b/src/Config.php
@@ -19,7 +19,6 @@ use Pusher\Exception\ConfigurationError;
  *     'app_id' => '1234',
  *     'timeout' => 5,
  *     'proxy_url' => 'http://localhost:8080',
- *     'adapter' => new CurlAdapter(array(CURLOPT_SSL_VERIFYPEER => 0)),
  *     'keys' => array(
  *       '75e854969fc5d1eef71b' => 'ea1fbae4b428e56e87b8',
  *     ),

--- a/src/Config.php
+++ b/src/Config.php
@@ -97,6 +97,10 @@ class Config
             $config = array('base_url' => $config);
         }
 
+        if (isset($config['encrypted'])) {
+            $this->defaults['scheme'] = ($config['encrypted'] === true) ? 'https' : 'http';
+        }
+
         if (!isset($config['base_url'])) {
             $config['base_url'] = $this->defaults['scheme'] . '://' . $this->defaults['host'];
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -54,7 +54,7 @@ class Config
      * @var array
      */
     protected $defaults = array(
-        'scheme' => 'http',
+        'scheme' => 'https',
         'host' => 'api.pusherapp.com',
     );
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -50,7 +50,7 @@ class Config
     public $adapter;
 
     /**
-     *
+     * Default components of the baseUrl.
      *
      * @var array
      */

--- a/src/Config.php
+++ b/src/Config.php
@@ -15,7 +15,8 @@ use Pusher\Exception\ConfigurationError;
  *
  * Full example:
  *   new Config(array(
- *     'base_url' => 'http://api.pusherapp.com/apps/78225',
+ *     'base_url' => 'http://api.pusherapp.com',
+ *     'app_id' => '1234',
  *     'timeout' => 5,
  *     'proxy_url' => 'http://localhost:8080',
  *     'adapter' => new CurlAdapter(array(CURLOPT_SSL_VERIFYPEER => 0)),
@@ -49,25 +50,19 @@ class Config
     public $adapter;
 
     /**
+     *
+     *
+     * @var array
+     */
+    protected $defaults = array(
+        'scheme' => 'http',
+        'host' => 'api.pusherapp.com',
+    );
+
+    /**
      * @var array of kind array(string => KeyPair)
      */
     private $keys = array();
-
-    /**
-     * Makes sure to return a Config object. If $config is already a Config
-     * instance it just returns it, otherwise a new one is created.
-     *
-     * @param $config string|array|Config
-     * @return Config
-     */
-    public static function ensure($config)
-    {
-        if (!$config instanceof Config) {
-            $config = new Config($config);
-            $config->validate();
-        }
-        return $config;
-    }
 
     /**
      * Returns an instance of the first adapter that is supported in the current
@@ -93,18 +88,24 @@ class Config
     /**
      * @param $config array|string
      */
-    public function __construct($config = array())
+    public function __construct($config)
     {
+        if (!is_string($config) && !is_array($config)) {
+            throw new ConfigurationError('You have not provided a valid configuration.');
+        }
+
         if (is_string($config)) {
             $config = array('base_url' => $config);
         }
 
-        if (isset($config['base_url'])) {
-            $url = $config['base_url'];
-            if (!empty($url)) {
-                $this->setBaseUrl($url);
-            }
+        if (!isset($config['base_url'])) {
+            $config['base_url'] = $this->defaults['scheme'] . '://' . $this->defaults['host'];
         }
+
+        $appUrl = (isset($config['app_id'])) ?
+            $config['base_url'] . '/apps/' . $config['app_id'] : $config['base_url'];
+
+        $this->setBaseUrl($appUrl);
 
         if (isset($config['keys']) && is_array($config['keys'])) {
             foreach ($config['keys'] as $key => $secret) {
@@ -116,21 +117,13 @@ class Config
             $this->proxyUrl = $config['proxy_url'];
         }
 
-        $adapter = null;
-        if (isset($config['adapter'])) {
-            $adapter = $config['adapter'];
-        }
-        if (empty($adapter)) {
-            $adapter = Config::detectAdapter($config);
-        }
-        $this->adapter = $adapter;
+        $this->adapter = Config::detectAdapter($config);
 
-        if (isset($config['timeout'])) {
-            $timeout = $config['timeout'];
-            if (is_int($timeout)) {
-                $this->timeout = $timeout;
-            }
+        if (isset($config['timeout']) && is_int($config['timeout'])) {
+            $this->timeout = $config['timeout'];
         }
+
+        $this->validate();
     }
 
     /**
@@ -204,19 +197,19 @@ class Config
     public function validate()
     {
         if (empty($this->baseUrl)) {
-            throw new ConfigurationError("baseUrl is missing");
+            throw new ConfigurationError("baseUrl is missing.");
         }
 
         if (empty($this->keys)) {
-            throw new ConfigurationError("keys are missing");
+            throw new ConfigurationError("keys are missing.");
         }
 
         if (empty($this->adapter)) {
-            throw new ConfigurationError("adapter is missing");
+            throw new ConfigurationError("adapter is missing.");
         }
 
         if (empty($this->timeout)) {
-            throw new ConfigurationError("timeout is not set");
+            throw new ConfigurationError("timeout is not set.");
         }
     }
 

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -9,11 +9,18 @@ class Pusher
 {
 
     /**
-     *
+     * The configuration object.
      *
      * @var Config
      */
     public $config;
+
+    /**
+     * The api client instance.
+     *
+     * @var Client
+     */
+    public $client;
 
     /**
      * Entry point of the api. Simply instantiates the library Config object.

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -9,16 +9,31 @@ class Pusher
 {
 
     /**
+     *
+     *
      * @var Config
      */
     public $config;
 
     /**
-     * @throws \Pusher\Exception\ConfigurationError
+     * Entry point of the api. Simply instantiates the library Config object.
+     *
+     * @param string $appId
+     * @param string $key
+     * @param string $secret
+     * @param array $options
+     * @return void
      */
-    public function __construct($config)
+    public function __construct($appId, $key, $secret, $options = array())
     {
-        $this->config = Config::ensure($config);
+        $options = array_merge($options, array(
+            'app_id' => $appId,
+            'keys' => array(
+                $key => $secret,
+            ),
+        ));
+
+        $this->config = new Config($options);
         $this->client = new Client($this->config);
     }
 
@@ -84,11 +99,11 @@ class Pusher
      * @param $channels string|array A list of channels to send the event to
      * @param $event string name of the event
      * @param $data array data associated to the event
-     * @param $socket_id string|null
-     * @throws \Exception\HTTPError on invalid responses
+     * @param $socketId string|null
+     * @throws \Exception\Exception on invalid responses
      * @return array
      */
-    public function trigger($channels, $event, $data, $socket_id = null)
+    public function trigger($channels, $event, $data, $socketId = null)
     {
         $channels = (array)$channels;
 
@@ -103,8 +118,8 @@ class Pusher
         $body['data'] = $data;
         $body['channels'] = $channels;
 
-        if ($socket_id) {
-            $body['socket_id'] = $socket_id;
+        if ($socketId) {
+            $body['socket_id'] = $socketId;
         }
 
         return $this->client->post('events', $body);

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -2,6 +2,8 @@
 
 namespace Pusher;
 
+use Pusher\Exception\ConfigurationError;
+
 /**
  * Main class used to interact with the pusher API and related constructs.
  */
@@ -31,16 +33,25 @@ class Pusher
      * @param array $options
      * @return void
      */
-    public function __construct($appId, $key, $secret, $options = array())
+    public function __construct($appId, $key = null, $secret = null, $options = array())
     {
-        $options = array_merge($options, array(
-            'app_id' => $appId,
-            'keys' => array(
-                $key => $secret,
-            ),
-        ));
+        if ($appId instanceof Config) {
+            $this->config = $appId;
+        } else {
+            if (!is_string($key) && !is_string($secret)) {
+                throw new ConfigurationError('Missing app key and secret.');
+            }
 
-        $this->config = new Config($options);
+            $options = array_merge($options, array(
+                'app_id' => $appId,
+                'keys' => array(
+                    $key => $secret,
+                ),
+            ));
+
+            $this->config = new Config($options);
+        }
+
         $this->client = new Client($this->config);
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -3,42 +3,43 @@
 namespace Pusher\Tests;
 
 use Pusher\Client;
+use Pusher\Config;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        $this->c = new Client(new Config(array(
+            'base_url' => 'http://a:b@foobar.com',
+        )));
+    }
 
     public function testConstrcutor()
     {
-        $c = new Client(array(
-            'base_url' => 'http://a:b@foobar.com',
-        ));
-        $this->assertEquals('http://foobar.com', $c->baseUrl);
-        $this->assertInstanceOf('Pusher\HTTPAdapter', $c->adapter);
-        $this->assertEquals(5, $c->timeout);
-        $this->assertNull($c->proxyUrl);
-        $this->assertInstanceOf('Pusher\KeyPair', $c->keyPair);
+        $this->assertEquals('http://foobar.com', $this->c->baseUrl);
+        $this->assertInstanceOf('Pusher\HTTPAdapter', $this->c->adapter);
+        $this->assertEquals(5, $this->c->timeout);
+        $this->assertNull($this->c->proxyUrl);
+        $this->assertInstanceOf('Pusher\KeyPair', $this->c->keyPair);
     }
 
     public function testRequest()
     {
-        $c = new Client(array(
-            'base_url' => 'http://a:b@foobar.com',
-        ));
-        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
-        $c->adapter
+        $this->c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $this->c->adapter
             ->expects($this->once())
             ->method('request')
             ->will($this->returnValue(array('status' => 200, 'body' => '{"data":"A Pusher message"}')));
-        $result = $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+        $result = $this->c->request('GET', '/bar/foo', array('bill' => 'ben'));
         $this->assertInstanceOf('\stdClass', $result);
         $this->assertEquals('A Pusher message', $result->data);
 
-        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
-        $c->adapter
+        $this->c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $this->c->adapter
             ->expects($this->once())
             ->method('request')
             ->will($this->returnValue(array('status' => 202)));
-        $result = $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+        $result = $this->c->request('GET', '/bar/foo', array('bill' => 'ben'));
         $this->assertTrue($result);
     }
 
@@ -48,15 +49,12 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testRequest400Error()
     {
-        $c = new Client(array(
-            'base_url' => 'http://a:b@foobar.com',
-        ));
-        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
-        $c->adapter
+        $this->c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $this->c->adapter
             ->expects($this->once())
             ->method('request')
             ->will($this->returnValue(array('status' => 400)));
-        $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+        $this->c->request('GET', '/bar/foo', array('bill' => 'ben'));
     }
 
     /**
@@ -65,15 +63,12 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testRequest401Error()
     {
-        $c = new Client(array(
-            'base_url' => 'http://a:b@foobar.com',
-        ));
-        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
-        $c->adapter
+        $this->c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $this->c->adapter
             ->expects($this->once())
             ->method('request')
             ->will($this->returnValue(array('status' => 401)));
-        $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+        $this->c->request('GET', '/bar/foo', array('bill' => 'ben'));
     }
 
     /**
@@ -82,15 +77,12 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testRequest404Error()
     {
-        $c = new Client(array(
-            'base_url' => 'http://a:b@foobar.com',
-        ));
-        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
-        $c->adapter
+        $this->c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $this->c->adapter
             ->expects($this->once())
             ->method('request')
             ->will($this->returnValue(array('status' => 404)));
-        $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+        $this->c->request('GET', '/bar/foo', array('bill' => 'ben'));
     }
 
     /**
@@ -99,15 +91,12 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testRequest407Error()
     {
-        $c = new Client(array(
-            'base_url' => 'http://a:b@foobar.com',
-        ));
-        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
-        $c->adapter
+        $this->c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $this->c->adapter
             ->expects($this->once())
             ->method('request')
             ->will($this->returnValue(array('status' => 407)));
-        $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+        $this->c->request('GET', '/bar/foo', array('bill' => 'ben'));
     }
 
     /**
@@ -116,43 +105,34 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testRequestUnknownError()
     {
-        $c = new Client(array(
-            'base_url' => 'http://a:b@foobar.com',
-        ));
-        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
-        $c->adapter
+        $this->c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $this->c->adapter
             ->expects($this->once())
             ->method('request')
             ->will($this->returnValue(array('status' => 500)));
-        $c->request('GET', '/bar/foo', array('bill' => 'ben'));
+        $this->c->request('GET', '/bar/foo', array('bill' => 'ben'));
     }
 
     public function testGetRequest()
     {
-        $c = new Client(array(
-            'base_url' => 'http://a:b@foobar.com',
-        ));
-        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
-        $c->adapter
+        $this->c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $this->c->adapter
             ->expects($this->once())
             ->method('request')
             ->will($this->returnValue(array('status' => 200, 'body' => '{"data":"A Pusher message"}')));
-        $result = $c->get('/foo/bar', array('bill' => 'ben'));
+        $result = $this->c->get('/foo/bar', array('bill' => 'ben'));
         $this->assertInstanceOf('\stdClass', $result);
         $this->assertEquals('A Pusher message', $result->data);
     }
 
     public function testPostRequest()
     {
-        $c = new Client(array(
-            'base_url' => 'http://a:b@foobar.com',
-        ));
-        $c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
-        $c->adapter
+        $this->c->adapter = $this->getMock('Pusher\CurlAdapter', array('request'));
+        $this->c->adapter
             ->expects($this->once())
             ->method('request')
             ->will($this->returnValue(array('status' => 200, 'body' => '{"data":"A Pusher message"}')));
-        $result = $c->post('/foo/bar', array('bill' => 'ben'));
+        $result = $this->c->post('/foo/bar', array('bill' => 'ben'));
         $this->assertInstanceOf('\stdClass', $result);
         $this->assertEquals('A Pusher message', $result->data);
     }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -38,6 +38,13 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'keys' => array('a' => 'b'),
         ));
         $this->assertEquals('https://api.pusherapp.com/apps/1234', $c->baseUrl);
+
+        $c = new Config(array(
+            'app_id' => '1234',
+            'keys' => array('a' => 'b'),
+            'encrypted' => false,
+        ));
+        $this->assertEquals('http://api.pusherapp.com/apps/1234', $c->baseUrl);
     }
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -37,7 +37,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'app_id' => '1234',
             'keys' => array('a' => 'b'),
         ));
-        $this->assertEquals('http://api.pusherapp.com/apps/1234', $c->baseUrl);
+        $this->assertEquals('https://api.pusherapp.com/apps/1234', $c->baseUrl);
     }
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -24,15 +24,25 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Pusher\Exception\ConfigurationError
+     * @expectedExceptionMessage You have not provided a valid configuration.
      */
-    public function testBaseUrlValidationError()
+    public function testInvalidConstructor()
     {
-        $c = new Config();
-        $c->validate();
+        $c = new Config(123456);
+    }
+
+    public function testDefaultUrlInConstructor()
+    {
+        $c = new Config(array(
+            'app_id' => '1234',
+            'keys' => array('a' => 'b'),
+        ));
+        $this->assertEquals('http://api.pusherapp.com/apps/1234', $c->baseUrl);
     }
 
     /**
      * @expectedException \Pusher\Exception\ConfigurationError
+     * @expectedExceptionMessage keys are missing.
      */
     public function testMissingKeysValidationError()
     {
@@ -44,6 +54,20 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Pusher\Exception\ConfigurationError
+     * @expectedExceptionMessage baseUrl is missing.
+     */
+    public function testMissingBaseUrlError()
+    {
+        $c = new Config(array(
+            'base_url' => 'http://a:b@foobar.com',
+        ));
+        $c->baseUrl = null;
+        $c->validate();
+    }
+
+    /**
+     * @expectedException \Pusher\Exception\ConfigurationError
+     * @expectedExceptionMessage adapter is missing.
      */
     public function testMissingAdapterError()
     {
@@ -56,6 +80,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Pusher\Exception\ConfigurationError
+     * @expectedExceptionMessage timeout is not set.
      */
     public function testTimeoutConfigError()
     {
@@ -99,16 +124,6 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->assertEquals('http://myproxy.com', $c->proxyUrl);
-    }
-
-    public function testWithAdapterOption()
-    {
-        $c = new Config(array(
-            'base_url' => 'http://a:b@foobar.com',
-            'adapter' => new \Pusher\FileAdapter(),
-        ));
-
-        $this->assertInstanceOf('Pusher\FileAdapter', $c->adapter);
     }
 
     public function testSetBaseUrl()

--- a/tests/FileAdapterTest.php
+++ b/tests/FileAdapterTest.php
@@ -9,7 +9,7 @@ class FileAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        if (getenv('TRAVIS')) {
+        if (getenv('TRAVIS') || ini_get('allow_url_fopen') != '1') {
             $this->markTestSkipped();
         }
     }

--- a/tests/PusherTest.php
+++ b/tests/PusherTest.php
@@ -83,7 +83,6 @@ class PusherTest extends \PHPUnit_Framework_TestCase
                         )
                     ),
                 )
-
             );
 
         $this->Pusher->trigger('my-message', 'new-message', array('body' => 'Hello'));

--- a/tests/PusherTest.php
+++ b/tests/PusherTest.php
@@ -14,6 +14,23 @@ class PusherTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    /**
+     * @expectedException \Pusher\Exception\ConfigurationError
+     * @expectedExceptionMessage Missing app key and secret.
+     */
+    public function testMissingParamsError()
+    {
+        new Pusher('1234');
+    }
+
+    public function testConstructorWithConfigObject()
+    {
+        $config = new Config('http://a:b@foobar.com/apps/1234');
+        $pusher = new Pusher($config);
+
+        $this->assertEquals($config, $pusher->config);
+    }
+
     public function testConstructor()
     {
         $this->assertInstanceOf('Pusher\Config', $this->Pusher->config);

--- a/tests/PusherTest.php
+++ b/tests/PusherTest.php
@@ -3,36 +3,38 @@
 namespace Pusher\Tests;
 
 use Pusher\Pusher;
+use Pusher\Config;
 
 class PusherTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        $this->Pusher = new Pusher('1234', 'a', 'b', array(
+            'base_url' => 'http://foobar.com',
+        ));
+    }
 
     public function testConstructor()
     {
-        $Pusher = new Pusher('http://a:b@foobar.com');
-
-        $this->assertInstanceOf('Pusher\Config', $Pusher->config);
-        $this->assertInstanceOf('Pusher\Client', $Pusher->client);
+        $this->assertInstanceOf('Pusher\Config', $this->Pusher->config);
+        $this->assertInstanceOf('Pusher\Client', $this->Pusher->client);
     }
 
     public function testKeyPair()
     {
-        $Pusher = new Pusher('http://a:b@foobar.com');
-
-        $this->assertInstanceOf('Pusher\KeyPair', $Pusher->keyPair());
+        $this->assertInstanceOf('Pusher\KeyPair', $this->Pusher->keyPair());
     }
 
     public function testAuthenticate()
     {
-        $Pusher = new Pusher('http://a:b@foobar.com');
         $this->assertEquals(
             '{"auth":"a:a9e583c6fad5e38b69465bcff22fd809aac8b95fbdb9f7cae4bb27cb8e512f88"}',
-            $Pusher->authenticate('38087.11062758', 'private-messages')
+            $this->Pusher->authenticate('38087.11062758', 'private-messages')
         );
 
         $this->assertEquals(
             '{"auth":"a:8c30292debfdfdbc169bc7866a979936c886ea9fd70eb397f1facd55da5e3d2a","channel_data":"\"channel-data\""}',
-            $Pusher->authenticate('38087.11062758', 'private-messages', 'channel-data')
+            $this->Pusher->authenticate('38087.11062758', 'private-messages', 'channel-data')
         );
     }
 
@@ -43,8 +45,7 @@ class PusherTest extends \PHPUnit_Framework_TestCase
             'HTTP_X_PUSHER_SIGNATURE' => 'sdfkjq2jnk12je',
         );
 
-        $Pusher = new Pusher('http://a:b@foobar.com');
-        $result = $Pusher->webhook(null, __DIR__ . '/body1.txt');
+        $result = $this->Pusher->webhook(null, __DIR__ . '/body1.txt');
 
         $this->assertInstanceOf('Pusher\WebHook', $result);
         $this->assertEquals('sdfkjq2jnk12je', $result->signature);
@@ -55,10 +56,9 @@ class PusherTest extends \PHPUnit_Framework_TestCase
 
     public function testTrigger()
     {
-        $Pusher = new Pusher('http://a:b@foobar.com');
-
-        $Pusher->client = $this->getMock('Pusher\Client', array('post'), array('http://a:b@foobar.com'));
-        $Pusher->client
+        $config = new Config(array('base_url' => 'http://a:b@foobar.com'));
+        $this->Pusher->client = $this->getMock('Pusher\Client', array('post'), array($config));
+        $this->Pusher->client
             ->expects($this->exactly(2))
             ->method('post')
             ->withConsecutive(
@@ -86,8 +86,8 @@ class PusherTest extends \PHPUnit_Framework_TestCase
 
             );
 
-        $Pusher->trigger('my-message', 'new-message', array('body' => 'Hello'));
-        $Pusher->trigger('my-message', 'new-message', array('body' => 'Hello'), '12345');
+        $this->Pusher->trigger('my-message', 'new-message', array('body' => 'Hello'));
+        $this->Pusher->trigger('my-message', 'new-message', array('body' => 'Hello'), '12345');
     }
 
     /**
@@ -96,8 +96,7 @@ class PusherTest extends \PHPUnit_Framework_TestCase
      */
     public function testTriggerThrowsError()
     {
-        $Pusher = new Pusher('http://a:b@foobar.com');
-        $Pusher->trigger(
+        $this->Pusher->trigger(
             array(
                 'my-message1',
                 'my-message2',
@@ -118,43 +117,43 @@ class PusherTest extends \PHPUnit_Framework_TestCase
 
     public function testChannels()
     {
-        $Pusher = new Pusher('http://a:b@foobar.com');
-        $Pusher->client = $this->getMock('Pusher\Client', array('get'), array('http://a:b@foobar.com'));
-        $Pusher->client
+        $config = new Config(array('base_url' => 'http://a:b@foobar.com'));
+        $this->Pusher->client = $this->getMock('Pusher\Client', array('get'), array($config));
+        $this->Pusher->client
             ->expects($this->once())
             ->method('get')
             ->with(
                 $this->equalTo('/channels'),
                 $this->equalTo(array('bill' => 'ben'))
             );
-        $Pusher->channels(array('bill' => 'ben'));
+        $this->Pusher->channels(array('bill' => 'ben'));
     }
 
     public function testChannelInfo()
     {
-        $Pusher = new Pusher('http://a:b@foobar.com');
-        $Pusher->client = $this->getMock('Pusher\Client', array('get'), array('http://a:b@foobar.com'));
-        $Pusher->client
+        $config = new Config(array('base_url' => 'http://a:b@foobar.com'));
+        $this->Pusher->client = $this->getMock('Pusher\Client', array('get'), array($config));
+        $this->Pusher->client
             ->expects($this->once())
             ->method('get')
             ->with(
                 $this->equalTo('/channels/foo'),
                 $this->equalTo(array('bill' => 'ben'))
             );
-        $Pusher->channelInfo('foo', array('bill' => 'ben'));
+        $this->Pusher->channelInfo('foo', array('bill' => 'ben'));
     }
 
     public function testPresenceUsers()
     {
-        $Pusher = new Pusher('http://a:b@foobar.com');
-        $Pusher->client = $this->getMock('Pusher\Client', array('get'), array('http://a:b@foobar.com'));
-        $Pusher->client
+        $config = new Config(array('base_url' => 'http://a:b@foobar.com'));
+        $this->Pusher->client = $this->getMock('Pusher\Client', array('get'), array($config));
+        $this->Pusher->client
             ->expects($this->once())
             ->method('get')
             ->with(
                 $this->equalTo('/channels/foo/users'),
                 $this->equalTo(array('bill' => 'ben'))
             );
-        $Pusher->presenceUsers('foo', array('bill' => 'ben'));
+        $this->Pusher->presenceUsers('foo', array('bill' => 'ben'));
     }
 }


### PR DESCRIPTION
Here's my attempt at modifying the Pusher signature. It now takes the form:

```php
$Pusher = new Pusher($appId, $appKey, $appSecret, $options);
```
The options array can take the following keys: `base_url, timeout, proxy_url`. 

The PR also includes test updates and some more PSR2 cs changes.

Covers #66 

Thanks :)