### PR TITLE
Can now specify which api cluster to use

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -55,7 +55,7 @@ class Config
      */
     protected $defaults = array(
         'scheme' => 'https',
-        'host' => 'api-useast2.pusher.com',
+        'host' => 'api.pusherapp.com',
     );
 
     /**
@@ -102,7 +102,7 @@ class Config
         }
 
         if (isset($config['cluster'])) {
-            $this->defaults['host'] = str_replace('useast2', $config['cluster'], $this->defaults['host']);
+            $this->defaults['host'] = 'api-' . $config['cluster'] . '.pusher.com';
         }
 
         if (!isset($config['base_url'])) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -55,7 +55,7 @@ class Config
      */
     protected $defaults = array(
         'scheme' => 'https',
-        'host' => 'api.pusherapp.com',
+        'host' => 'api-useast2.pusher.com',
     );
 
     /**
@@ -99,6 +99,10 @@ class Config
 
         if (isset($config['encrypted'])) {
             $this->defaults['scheme'] = ($config['encrypted'] === true) ? 'https' : 'http';
+        }
+
+        if (isset($config['cluster'])) {
+            $this->defaults['host'] = str_replace('useast2', $config['cluster'], $this->defaults['host']);
         }
 
         if (!isset($config['base_url'])) {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -37,14 +37,14 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'app_id' => '1234',
             'keys' => array('a' => 'b'),
         ));
-        $this->assertEquals('https://api-useast2.pusher.com/apps/1234', $c->baseUrl);
+        $this->assertEquals('https://api.pusherapp.com/apps/1234', $c->baseUrl);
 
         $c = new Config(array(
             'app_id' => '1234',
             'keys' => array('a' => 'b'),
             'encrypted' => false,
         ));
-        $this->assertEquals('http://api-useast2.pusher.com/apps/1234', $c->baseUrl);
+        $this->assertEquals('http://api.pusherapp.com/apps/1234', $c->baseUrl);
     }
 
     public function testClusterUrl()

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -37,14 +37,24 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             'app_id' => '1234',
             'keys' => array('a' => 'b'),
         ));
-        $this->assertEquals('https://api.pusherapp.com/apps/1234', $c->baseUrl);
+        $this->assertEquals('https://api-useast2.pusher.com/apps/1234', $c->baseUrl);
 
         $c = new Config(array(
             'app_id' => '1234',
             'keys' => array('a' => 'b'),
             'encrypted' => false,
         ));
-        $this->assertEquals('http://api.pusherapp.com/apps/1234', $c->baseUrl);
+        $this->assertEquals('http://api-useast2.pusher.com/apps/1234', $c->baseUrl);
+    }
+
+    public function testClusterUrl()
+    {
+        $c = new Config(array(
+            'app_id' => '1234',
+            'keys' => array('a' => 'b'),
+            'cluster' => 'eu',
+        ));
+        $this->assertEquals('https://api-eu.pusher.com/apps/1234', $c->baseUrl);
     }
 
     /**


### PR DESCRIPTION
This solves #70 - the default api host is now set to the useast.

Regards