### PR TITLE
Add php 7 to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:
@@ -16,4 +17,5 @@ script: make test
 matrix:
   allow_failures:
     - php: hhvm
+    - php: 7.0
   fast_finish: true


### PR DESCRIPTION
The first release candidate for php 7 has been available for a few weeks now. Makes sense to start testing against it!

Regards