### PR TITLE
Fixed example

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,18 +136,20 @@ Next, create the following in presence_auth.php:
 
 ```php
 <?php
-header('Content-Type: application/json');
 if (isset($_SESSION['user_id'])) {
   $stmt = $pdo->prepare("SELECT * FROM `users` WHERE id = :id");
-  $stmt->bindValue(':id', $_SESSION['user_id'], \PDO::PARAM_INT);
+  $stmt->bindValue(':id', $_SESSION['user_id'], PDO::PARAM_INT);
   $stmt->execute();
   $user = $stmt->fetch();
 } else {
   die('aaargh, no-one is logged in')
 }
 
+header('Content-Type: application/json');
+
 $pusher = new Pusher($key, $secret, $app_id);
 $presence_data = array('name' => $user['name']);
+
 echo $pusher->presence_auth($_POST['channel_name'], $_POST['socket_id'], $user['id'], $presence_data);
 ```
 


### PR DESCRIPTION
If we end up calling "die", then the content type isn't actually json.

The other fix is to remove the leading slash for php 5.2 computability, and it shouldn't be there on php 5.3 anyway. It would only be needed if we were working in a namespace.