### PR TITLE
curl handle was not reusable unless reset

### DIFF
--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -249,7 +249,9 @@ class Pusher
 		}
 
 		// curl handle is not reusable unless reset
-		curl_reset($ch);
+		if (function_exists('curl_reset')) {
+			curl_reset($ch);
+		}
 
 		# Set cURL opts and execute request
 		curl_setopt( $ch, CURLOPT_URL, $full_url );

--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -248,6 +248,9 @@ class Pusher
 			throw new PusherException('Could not initialise cURL!');
 		}
 
+		// curl handle is not reusable unless reset
+		curl_reset($ch);
+
 		# Set cURL opts and execute request
 		curl_setopt( $ch, CURLOPT_URL, $full_url );
 		curl_setopt( $ch, CURLOPT_HTTPHEADER, array ( "Content-Type: application/json", "Expect:" ) );


### PR DESCRIPTION
In some cases, the curl handle was not reusable unless being reset using `curl_reset($ch)`.
Test suite is passing without significant performance impact.