### PR TITLE
json_encode might fail and that should be logged

### DIFF
--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -18,6 +18,7 @@
 		+ Zack Kitzmiller (delicious@zackisamazing.com)
 		+ Andrew Bender (igothelp@gmail.com)
 		+ Phil Leggetter (phil@leggetter.co.uk)
+		+ Simaranjit Singh (simaranjit.singh@virdi.me)
 */
 
 class PusherException extends Exception
@@ -362,6 +363,11 @@ class Pusher
 		$s_url = $this->settings['base_path'] . '/events';
 
 		$data_encoded = $already_encoded ? $data : json_encode( $data );
+
+		// json_encode might return false on failure
+		if (!$data_encoded) {
+			$this->Log('Failed to perform json_encode on the the provided data: ' . print_r( $data, true ));
+		}
 
 		$post_params = array();
 		$post_params[ 'name' ] = $event;


### PR DESCRIPTION
As per http://php.net/json_encode
> Returns a JSON encoded string on success or FALSE on failure. 

This has not been taken care in the current library and packet is sent as `false` in case of failure. In response, server returns:
```
Pusher: exec_curl response: Array
(
    [body] => Missing required parameter: data

    [status] => 400
)
```
Nobody is able to track the actual packet caused this issue because that is not getting logged anywhere.

Ideally, system should log information with the content if anything goes wrong and then proceed further. 
