### PR TITLE
Fix for failures when doing multiple pusher requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.3.3
   - 5.3
   - 5.4
   - 5.5

--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -319,7 +319,7 @@ class Pusher
         if ($response['body'] === false) {
             $this->log('exec_curl error: '.curl_error($ch));
         }
-        
+
         return $response;
     }
 

--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -319,10 +319,7 @@ class Pusher
         if ($response['body'] === false) {
             $this->log('exec_curl error: '.curl_error($ch));
         }
-
-        curl_close($ch);
-        $ch = null;
-
+        
         return $response;
     }
 


### PR DESCRIPTION
One of the latest [commits](https://github.com/pusher/pusher-http-php/pull/97/commits/ef44c869227db989e8c7d083a5d71c8e53c265e7) closes the curl handler at the end of submitting a request.

In PHP7, this seems to work fine (as closing a curl handler sets the curl handler to be null), on PHP5.5 it will continue to be tagged as a resource (but as an `unknown` resource rather than a `curl` resource) so it'll fail when it comes round to create_curl as it checks if it's null rather than whether it's actually a curl resource.

The attempt to set $ch to null immediately after curl_close will do nothing as $ch in itself isn't byref, only the actual object is.

The long and short of this is, this change means that on PHP 5.5 if you try and send two messages, it'll work for the first message and fail for all subsequent messages. 

As I assume the `static $ch` is entirely for the point of reusing the curl handler for efficiency purposes, I've removed the curl_close again. If the curl_close is wanted (you could argue either way, and probably argue it's a macro-optimisation either way) I would propose moving $ch object to being on the class so you can easily do `$this->ch = null` which would negate this issue.