### PR TITLE
Fixing abolute bool value test

### DIFF
--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -533,7 +533,7 @@ class Pusher
         $this->validate_channel($channel);
         $this->validate_socket_id($socket_id);
 
-        if ($custom_data === true) {
+        if ($custom_data != true && is_string($custom_data)) {
             $signature = hash_hmac('sha256', $socket_id.':'.$channel.':'.$custom_data, $this->settings['secret'], false);
         } else {
             $signature = hash_hmac('sha256', $socket_id.':'.$channel, $this->settings['secret'], false);


### PR DESCRIPTION
As outlined here, http://php.net/manual/en/language.operators.comparison.php, === represents an absolute value, meaning the value passed to that argument must be exactly a boolean true (which it isn't - it's a JSON string).