### PR TITLE
Add option to disable return of json in socket_auth and presence_auth

### DIFF
--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -574,10 +574,11 @@ class Pusher
      *
      * @param string $socket_id
      * @param string $custom_data
+     * @param bool $return_json
      *
      * @return string
      */
-    public function socket_auth($channel, $socket_id, $custom_data = null)
+    public function socket_auth($channel, $socket_id, $custom_data = null, $return_json = true)
     {
         $this->validate_channel($channel);
         $this->validate_socket_id($socket_id);
@@ -594,7 +595,7 @@ class Pusher
             $signature['channel_data'] = $custom_data;
         }
 
-        return json_encode($signature);
+        return ($return_json) ? json_encode($signature) : $signature;
     }
 
     /**
@@ -603,16 +604,17 @@ class Pusher
      * @param string $socket_id
      * @param string $user_id
      * @param mixed $user_info
+     * @param bool $return_json
      *
      * @return string
      */
-    public function presence_auth($channel, $socket_id, $user_id, $user_info = null)
+    public function presence_auth($channel, $socket_id, $user_id, $user_info = null, $return_json = true)
     {
         $user_data = array('user_id' => $user_id);
         if ($user_info) {
             $user_data['user_info'] = $user_info;
         }
 
-        return $this->socket_auth($channel, $socket_id, json_encode($user_data));
+        return $this->socket_auth($channel, $socket_id, json_encode($user_data), $return_json);
     }
 }

--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -296,9 +296,9 @@ class Pusher
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_TIMEOUT, $this->settings['timeout']);
         if ($request_method === 'POST') {
-            curl_setopt($ch, CURLOPS_POST, 1);
+            curl_setopt($ch, CURLOPT_POST, 1);
         } elseif ($request_method === 'GET') {
-            curl_setopt($ch, CURLOPS_POST, 0);
+            curl_setopt($ch, CURLOPT_POST, 0);
         } // Otherwise let the user configure it
 
         // Set custom curl options


### PR DESCRIPTION
I added a boolean to disable the return of json encoded data in `socket_auth()` and `presence_auth()` functions. Sometimes I want to create my own JSON response in my apps.
