### PR TITLE
Curl method reset during get call

### DIFF
--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -558,7 +558,7 @@ class Pusher
 
         $ch = $this->create_curl($s_url, 'GET', $params);
 		
-		curl_setopt($ch, CURLOPT_POST, 0);
+        curl_setopt($ch, CURLOPT_POST, 0);
 
         $response = $this->exec_curl($ch);
 

--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -557,6 +557,8 @@ class Pusher
         $s_url = $this->settings['base_path'].$path;
 
         $ch = $this->create_curl($s_url, 'GET', $params);
+		
+		curl_setopt($ch, CURLOPT_POST, 0);
 
         $response = $this->exec_curl($ch);
 

--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -557,7 +557,7 @@ class Pusher
         $s_url = $this->settings['base_path'].$path;
 
         $ch = $this->create_curl($s_url, 'GET', $params);
-		
+
         curl_setopt($ch, CURLOPT_POST, 0);
 
         $response = $this->exec_curl($ch);


### PR DESCRIPTION
*Problem*
`$ch` variable is defined as static variable and kind of singleton pattern is followed to handle this. So, problem is, If two consecutive  requests are made, first is Post, second is Get, in this case system might send second request of Post type too which is fundamentally wrong. 

*How it has been fixed*
Get method should set CURLOPT_POST to 0 to avoid any kind of conflicts. 