### PR TITLE
Allow 'curl_options' option to be set via constructor.

### DIFF
--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -65,6 +65,7 @@ class Pusher
         'port' => 80,
         'timeout' => 30,
         'debug' => false,
+        'curl_options' => array(),
     );
     private $logger = null;
     private $ch = null; // Curl handler

--- a/test/unit/pusherConstructorTest.php
+++ b/test/unit/pusherConstructorTest.php
@@ -138,4 +138,16 @@
             $settings = $pusher->getSettings();
             $this->assertEquals('api.staging.pusher.com', $settings['host']);
         }
+        
+        public function testCurlOptionsCanBeSet()
+        {
+            $curl_opts = array( CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4 );
+            $options = array(
+                'curl_options' => $curl_opts,
+            );
+            $pusher = new Pusher('app_key', 'app_secret', 'app_id', $options);
+
+            $settings = $pusher->getSettings();
+            $this->assertEquals($curl_opts, $settings['curl_options']);
+        }
     }


### PR DESCRIPTION
The 'curl_options' parameter currently can't be set successfully via the constructor.  This change adds a default value for curl_options such that they successfully pass the 'foreach' on line 145.
