### PR TITLE
Fix string concatenation

### DIFF
--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -115,8 +115,8 @@ class Pusher
 
             $this->settings['host'] = $host;
 
-            $this->log('Legacy $host parameter provided: '.
-                                    $this->settings['scheme'] + ' host: ' + $this->settings['host']);
+            $this->log('Legacy $host parameter provided: ' .
+                                    $this->settings['scheme'] . ' host: ' . $this->settings['host']);
         }
 
         if (!is_null($port)) {


### PR DESCRIPTION
This was producing the error "ErrorException: A non-numeric value encountered in /vendor/pusher/pusher-php-server/lib/Pusher.php:119" when using a custom host.