### PR TITLE
Fix return type on trigger method

### DIFF
--- a/lib/Pusher.php
+++ b/lib/Pusher.php
@@ -445,7 +445,7 @@ class Pusher
      * @param bool   $debug           [optional]
      * @param bool   $already_encoded [optional]
      *
-     * @return bool|string
+     * @return bool|array
      */
     public function trigger($channels, $event, $data, $socket_id = null, $debug = false, $already_encoded = false)
     {


### PR DESCRIPTION
Currently, Pusher::trigger()'s docblock says that it will return `bool|string` which is incorrect since `exec_curl` returns an array (body + status). The return type should be `bool|array`