### PR TITLE
Remove logging when trigger is used with a string

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -411,7 +411,6 @@ class Pusher
     public function trigger($channels, $event, $data, $socket_id = null, $debug = false, $already_encoded = false)
     {
         if (is_string($channels) === true) {
-            $this->log('->trigger received string channel "'.$channels.'". Converting to array.');
             $channels = array($channels);
         }
 


### PR DESCRIPTION
Logging is unnecessary when a string is parsed as a channel name. I actually think it's more common to send a push notification to 1 channel.
Discussed in #136 