### PR TITLE
Check curl handle explicitly for resource type instead of null.

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -253,7 +253,7 @@ class Pusher
         $this->log('INFO: create_curl( '.$full_url.' )');
 
         // Create or reuse existing curl handle
-        if (null === $this->ch) {
+        if (!is_resource($this->ch)) {
             $this->ch = curl_init();
         }
 


### PR DESCRIPTION
# Description

After updating lib version started seeing errors with curl_reset() in Pusher.php:268 saying that expected a `resource`  type but got an int (value: 0). 

Why and how `$ch` variables becomes `0` - I did not have enough time to dig deeper and reproduce it in isolated environment, but because `$ch` becomes `0` then curl_init() does not happen on attempt to reuse the handle. So the proposed fix is to check explicitly for `resource` type instead of `null`, which IMHO is more accurate and less error prone.

## Additional info
This might be due php/curl version combination, but its a long shot. Leaving here some details about the environment where it did happen, while I understand this might not be enough for reproducing the issue.

php version: 7.1.5 
curl version: curl 7.29.0 (x86_64-redhat-linux-gnu) libcurl/7.29.0 NSS/3.19.1 Basic ECC zlib/1.2.7 libidn/1.28 libssh2/1.4.3