### PR TITLE
Make acceptance tests work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ php:
   - 7.2
   - hhvm
 
+# Due to a compatibility issue between HHVM and PHP7
+# https://docs.travis-ci.com/user/languages/php/#HHVM-versions
+before_script:
+  - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
+
 install: travis_retry composer install --no-interaction --prefer-source
 
 script: vendor/bin/phpunit --testsuite unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
+  - hhvm-3.24
 
 # Due to a compatibility issue between HHVM and PHP7
 # https://docs.travis-ci.com/user/languages/php/#HHVM-versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ php:
   - 7.2
   - hhvm
 
-sudo: false
-
 install: travis_retry composer install --no-interaction --prefer-source
 
 script: vendor/bin/phpunit --testsuite unit

--- a/README.md
+++ b/README.md
@@ -370,11 +370,12 @@ will appear within the generated app output e.g. HTML.
 
 Requires [phpunit](https://github.com/sebastianbergmann/phpunit).
 
+* Run `composer install`
 * Go to the `test` directory
 * Rename `config.example.php` and replace the values with valid Pusher credentials **or** create environment variables.
 * Some tests require a client to be connected to the app you defined in the config;
   you can do this by opening https://dashboard.pusher.com/apps/<YOUR_TEST_APP_ID>/getting_started in the browser
-* From the root directory of the project, execute `phpunit .` to run all the tests.
+* From the root directory of the project, execute `composer exec phpunit` to run all the tests.
 
 ## Framework Integrations
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Requires [phpunit](https://github.com/sebastianbergmann/phpunit).
 * Go to the `test` directory
 * Rename `config.example.php` and replace the values with valid Pusher credentials **or** create environment variables.
 * Some tests require a client to be connected to the app you defined in the config;
-  you can do this by opening https://dashboard.pusher.com/apps/<YOUR_TEST_APP_ID>/console in the browser
+  you can do this by opening https://dashboard.pusher.com/apps/<YOUR_TEST_APP_ID>/getting_started in the browser
 * From the root directory of the project, execute `phpunit .` to run all the tests.
 
 ## Framework Integrations

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
             "Pusher\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": { "": "tests/" }
+    },
     "config": {
         "preferred-install": "dist"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
          backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/tests/acceptance/channelQueryTest.php
+++ b/tests/acceptance/channelQueryTest.php
@@ -54,7 +54,7 @@ class PusherChannelQueryTest extends PHPUnit_Framework_TestCase
     public function testFilterByPrefixOneChannel()
     {
         $options = array(
-            'filter_by_prefix' => 'test_',
+            'filter_by_prefix' => 'my-',
         );
         $result = $this->pusher->get_channels($options);
 
@@ -64,7 +64,7 @@ class PusherChannelQueryTest extends PHPUnit_Framework_TestCase
 
         // print_r( $channels );
 
-        $this->assertEquals(1, count($channels), 'channels have a single test-channel present. For this test to pass you must have your API Access setting open for the application you are testing against');
+        $this->assertEquals(1, count($channels), 'channels have a single test-channel present. For this test to pass you must have the "Getting Started" page open on the dashboard for the app you are testing against');
     }
 
     public function test_providing_info_parameter_with_prefix_query_fails_for_public_channel()
@@ -88,7 +88,7 @@ class PusherChannelQueryTest extends PHPUnit_Framework_TestCase
 
         $channels = $result['channels'];
 
-        $this->assertEquals(1, count($channels), 'channels have a single test-channel present. For this test to pass you must have your API Access setting open for the application you are testing against');
+        $this->assertEquals(1, count($channels), 'channels have a single test-channel present. For this test to pass you must have the "Getting Started" page open on the dashboard for the app you are testing against');
 
         $test_channel = $channels['test_channel'];
 
@@ -97,7 +97,7 @@ class PusherChannelQueryTest extends PHPUnit_Framework_TestCase
 
     public function test_channel_list_using_generic_get_and_prefix_param()
     {
-        $response = $this->pusher->get('/channels', array('filter_by_prefix' => 'test_'));
+        $response = $this->pusher->get('/channels', array('filter_by_prefix' => 'my-'));
 
         $this->assertEquals($response['status'], 200);
 
@@ -105,7 +105,7 @@ class PusherChannelQueryTest extends PHPUnit_Framework_TestCase
 
         $channels = $result['channels'];
 
-        $this->assertEquals(1, count($channels), 'channels have a single test-channel present. For this test to pass you must have your API Access setting open for the application you are testing against');
+        $this->assertEquals(1, count($channels), 'channels have a single test-channel present. For this test to pass you must have the "Getting Started" page open on the dashboard for the app you are testing against');
 
         $test_channel = $channels['test_channel'];
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,7 +11,3 @@ if (file_exists($config_path) === true) {
 
     define('PUSHERAPP_HOST', 'http://api.pusherapp.com');
 }
-
-require_once $dir.'/../lib/Pusher.php';
-
-require_once $dir.'/TestLogger.php';


### PR DESCRIPTION
At the moment nothing is loading the `tests/test_includes.php` file, which means that the credentials config.php file was not being loaded. Additionally, the test dependencies, like `tests/TestLogger.php` were not being loaded. I solved the former by including this file in `phpunit.xml.dist` (and renaming it `bootstrap.php`), and the latter by making use of composer's autoload feature.

On top of this, some of the acceptance tests were no longer compatible with the current dashboard, so I fixed these.

Can you let me know your thoughts on this @kn100?