### PR TITLE
Fix reference to undefined variable in TestLogger

### DIFF
--- a/tests/TestLogger.php
+++ b/tests/TestLogger.php
@@ -9,7 +9,7 @@ class TestLogger extends AbstractLogger
      */
     public function log($level, $message, array $context = array())
     {
-        $msg = sprintf('Pusher: %s: %s', strtoupper($level), $msg);
+        $msg = sprintf('Pusher: %s: %s', strtoupper($level), $message);
         $replacement = array();
 
         foreach ($context as $k => $v) {


### PR DESCRIPTION
Unfortunately the integration tests are not run by travis, so this was not picked up...