### PR TITLE
Ignore IDE files. On API error log body instead of empty error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ composer.lock
 phpunit.xml
 test/config.php
 vendor
+
+# Ignore all folders that starts with . (usually it's IDE's files)
+.*/

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -357,7 +357,11 @@ class Pusher implements LoggerAwareInterface
         $response['status'] = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
         if ($response['body'] === false || $response['status'] < 200 || 400 <= $response['status']) {
-            $this->log('exec_curl error: {error}', array('error' => curl_error($ch)), LogLevel::ERROR);
+            $this->log(
+                'exec_curl error: {error}',
+                array('error' => curl_errno($ch) !== 0 ? curl_error($ch) : $response['body']),
+                LogLevel::ERROR
+            );
         }
 
         $this->log('exec_curl response: {response}', array('response' => print_r($response, true)));


### PR DESCRIPTION
When there is API error, all it gets logged is `exec_curl error: ` because there is no actual cUrl error, only response from server with status 400 and body as error messages.

Fixes to use actual body if there is no cUrl error.