### PR TITLE
Fix scope of crypto variable

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -152,7 +152,7 @@ class Pusher implements LoggerAwareInterface
         preg_replace('/http[s]?\:\/\//', '', $this->settings['host'], 1);
 
         if ($this->settings['encryption_master_key'] != '') {
-            $crypto = new PusherCrypto($this->settings['encryption_master_key']);
+            $this->crypto = new PusherCrypto($this->settings['encryption_master_key']);
         }
     }
 


### PR DESCRIPTION
`crypto` needs to be a property of `Pusher` so it can be used in `trigger`, `socket_auth` etc.