### PR TITLE
Deprecate `encrypted` option; rename to `useTLS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,19 @@ The fourth parameter is an `$options` array. The additional options are:
 * `host` - the host e.g. api.pusherapp.com. No trailing forward slash.
 * `port` - the http port
 * `timeout` - the HTTP timeout
-* `encrypted` - quick option to use scheme of https and port 443.
+* `useTLS` - quick option to use scheme of https and port 443.
 * `cluster` - specify the cluster where the application is running from.
 * `curl_options` - array with custom curl commands
 
-For example, by default calls will be made over a non-encrypted connection. To change this to make calls over HTTPS use:
+For example, by default calls will be made over a non-TLS connection. To change this to make calls over HTTPS use:
 
 ```php
-$pusher = new Pusher\Pusher( $app_key, $app_secret, $app_id, array( 'cluster' => $app_cluster, 'encrypted' => true ) );
+$pusher = new Pusher\Pusher( $app_key, $app_secret, $app_id, array( 'cluster' => $app_cluster, 'useTLS' => true ) );
 ```
 
 For example, if you want to set custom curl options, use this:
 ```php
-$pusher = new Pusher\Pusher( $app_key, $app_secret, $app_id, array( 'cluster' => $app_cluster, 'encrypted' => true, 'curl_options' => array( CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4 ) ) );
+$pusher = new Pusher\Pusher( $app_key, $app_secret, $app_id, array( 'cluster' => $app_cluster, 'useTLS' => true, 'curl_options' => array( CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4 ) ) );
 ```
 
 

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -46,7 +46,8 @@ class Pusher implements LoggerAwareInterface
      *                         host - the host e.g. api.pusherapp.com. No trailing forward slash.
      *                         port - the http port
      *                         timeout - the http timeout
-     *                         encrypted - quick option to use scheme of https and port 443.
+     *                         useTLS - quick option to use scheme of https and port 443.
+     *                         encrypted - deprecated; renamed to `useTLS`.
      *                         cluster - cluster name to connect to.
      *                         notification_host - host to connect to for native notifications.
      *                         notification_scheme - scheme for the notification_host.
@@ -94,9 +95,15 @@ class Pusher implements LoggerAwareInterface
 
         /* End backward compatibility with old constructor **/
 
+        $useTLS = false;
+        if (isset($options['useTLS'])) {
+            $useTLS = $options['useTLS'] === true;
+        } elseif (isset($options['encrypted'])) {
+            // `encrypted` deprecated in favor of `forceTLS`
+            $useTLS = $options['encrypted'] === true;
+        }
         if (
-            isset($options['encrypted']) &&
-            $options['encrypted'] === true &&
+            $useTLS &&
             !isset($options['scheme']) &&
             !isset($options['port'])
         ) {

--- a/tests/acceptance/triggerBatchTest.php
+++ b/tests/acceptance/triggerBatchTest.php
@@ -27,11 +27,11 @@ class PusherBatchPushTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($string_trigger, 'Trigger with string payload');
     }
 
-    public function testEncryptedPush()
+    public function testTLSPush()
     {
         $options = array(
-            'encrypted' => true,
-            'host'      => PUSHERAPP_HOST,
+            'useTLS' => true,
+            'host'   => PUSHERAPP_HOST,
         );
         $pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, $options);
         $pusher->setLogger(new TestLogger());

--- a/tests/acceptance/triggerTest.php
+++ b/tests/acceptance/triggerTest.php
@@ -31,17 +31,17 @@ class PusherPushTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($structure_trigger, 'Trigger with structured payload');
     }
 
-    public function testEncryptedPush()
+    public function testTLSPush()
     {
         $options = array(
-            'encrypted' => true,
-            'host'      => PUSHERAPP_HOST,
+            'useTLS' => true,
+            'host'   => PUSHERAPP_HOST,
         );
         $pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, $options);
         $pusher->setLogger(new TestLogger());
 
         $structure_trigger = $pusher->trigger('test_channel', 'my_event', array('encrypted' => 1));
-        $this->assertTrue($structure_trigger, 'Trigger with over encrypted connection');
+        $this->assertTrue($structure_trigger, 'Trigger with over TLS connection');
     }
 
     public function testSendingOver10kBMessageReturns413()

--- a/tests/unit/pusherConstructorTest.php
+++ b/tests/unit/pusherConstructorTest.php
@@ -66,9 +66,9 @@ class pusherConstructorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($timeout, $settings['timeout']);
     }
 
-    public function testEncryptedOptionWillSetHostAndPort()
+    public function testUseTLSOptionWillSetHostAndPort()
     {
-        $options = array('encrypted' => true);
+        $options = array('useTLS' => true);
         $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', $options);
 
         $settings = $pusher->getSettings();
@@ -77,12 +77,12 @@ class pusherConstructorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('443', $settings['port']);
     }
 
-    public function testEncryptedOptionWillBeOverwrittenByHostAndPortOptionsSetHostAndPort()
+    public function testUseTLSOptionWillBeOverwrittenByHostAndPortOptionsSetHostAndPort()
     {
         $options = array(
-            'encrytped' => true,
-            'host'      => 'test.com',
-            'port'      => '3000',
+            'useTLS' => true,
+            'host'   => 'test.com',
+            'port'   => '3000',
         );
         $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', $options);
 


### PR DESCRIPTION
Rename `encrypted` to `useTLS`. This keeps the encrypted around, but it is deprecated.

We are doing this because `encrypted` is easily confused with our end-to-end encryption feature.