### PR TITLE
Fix trigger behaviour with mixed encrypted and non-encrypted channels + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The fourth parameter is an `$options` array. The additional options are:
 * `useTLS` - quick option to use scheme of https and port 443.
 * `cluster` - specify the cluster where the application is running from.
 * `curl_options` - array with custom curl commands
-* `encryption_master_key` - a 32 character long key used to derive secrets for end to end encryption (see below!)
+* `encryption_master_key` - a 32 char long key. This key, along with the channel name, are used to derive per-channel encryption keys. Per-channel keys are used encrypt event data on encrypted channels.
 
 For example, by default calls will be made over a non-TLS connection. To change this to make calls over HTTPS use:
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ $pusher = new Pusher\Pusher($app_key, $app_secret, $app_id, array(
 
 **Important note: This will __not__ encrypt messages on channels that are not prefixed by `private-encrypted-`.**
 
+**Limitation**: you cannot trigger a single event on multiple channels in a call to `trigger`, e.g.
+
+```php
+$data['name'] = 'joe';
+$data['message_count'] = 23;
+
+$pusher->trigger(array('channel-1', 'private-encrypted-channel-2'), 'test_event', $data);
+```
+
+Rationale: the methods in this library map directly to individual Channels HTTP API requests. If we allowed triggering a single event on multiple channels (some encrypted, some unencrypted), then it would require two API requests: one where the event is encrypted to the encrypted channels, and one where the event is unencrypted for unencrypted channels.
+
 ### Presence example
 
 First set this variable in your JS app:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The fourth parameter is an `$options` array. The additional options are:
 * `cluster` - specify the cluster where the application is running from.
 * `curl_options` - array with custom curl commands
 * `encryption_master_key` - a 32 char long key. This key, along with the channel name, are used to derive per-channel encryption keys. Per-channel keys are used encrypt event data on encrypted channels.
+* `debug` - (default `false`) if `true`, every `trigger()` and `triggerBatch()` call will return a `$response` object (e.g.): ```Array ([body] => {} [status] => 200)```
 
 For example, by default calls will be made over a non-TLS connection. To change this to make calls over HTTPS use:
 

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -504,8 +504,8 @@ class Pusher implements LoggerAwareInterface
             }
         }
 
-        if($has_encrypted_channel){
-            if(sizeof($channels) > 1){
+        if ($has_encrypted_channel) {
+            if (count($channels) > 1) {
                 // For rationale, see limitations of end-to-end encryption in the README
                 throw new PusherException('You cannot trigger to multiple channels when using encrypted channels');
             } else {

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -55,6 +55,9 @@ class Pusher implements LoggerAwareInterface
      *                         useTLS - quick option to use scheme of https and port 443.
      *                         encrypted - deprecated; renamed to `useTLS`.
      *                         cluster - cluster name to connect to.
+     *                         encryption_master_key - the encryption master key used to encrypt events' data for private-encrypted channels
+     *                         debug - debug mode
+     *                         curl_options - wrapper for curl_setopt, more here: http://php.net/manual/en/function.curl-setopt.php
      *                         notification_host - host to connect to for native notifications.
      *                         notification_scheme - scheme for the notification_host.
      * @param string $host     [optional] - deprecated
@@ -494,11 +497,27 @@ class Pusher implements LoggerAwareInterface
         $this->validate_channels($channels);
         $this->validate_socket_id($socket_id);
 
+        $has_encrypted_channel = false;
+        foreach ($channels as $chan) {
+            if (PusherCrypto::is_encrypted_channel($chan)) {
+                $has_encrypted_channel = true;
+            }
+        }
+
+        if($has_encrypted_channel){
+            if(sizeof($channels) > 1){
+                // For rationale, see limitations of end-to-end encryption in the README
+                throw new PusherException('You cannot trigger to multiple channels when using encrypted channels');
+            } else {
+                $data_encoded = $this->crypto->encrypt_payload($channels[0], $already_encoded ? $data : json_encode($data));
+            }
+        } else {
+            $data_encoded = $already_encoded ? $data : json_encode($data);
+        }
+
         $query_params = array();
 
         $s_url = $this->settings['base_path'].'/events';
-
-        $data_encoded = $already_encoded ? $data : json_encode($data);
 
         // json_encode might return false on failure
         if (!$data_encoded) {
@@ -506,9 +525,7 @@ class Pusher implements LoggerAwareInterface
                 'error' => print_r($data, true),
             ), LogLevel::ERROR);
         }
-        if (PusherCrypto::is_encrypted_channel($channels[0])) {
-            $data_encoded = $this->crypto->encrypt_payload($channels[0], $data_encoded);
-        }
+
         $post_params = array();
         $post_params['name'] = $event;
         $post_params['data'] = $data_encoded;

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -55,7 +55,7 @@ class Pusher implements LoggerAwareInterface
      *                         useTLS - quick option to use scheme of https and port 443.
      *                         encrypted - deprecated; renamed to `useTLS`.
      *                         cluster - cluster name to connect to.
-     *                         encryption_master_key - the encryption master key used to encrypt events' data for private-encrypted channels
+     *                         encryption_master_key - a 32 char long key. This key, along with the channel name, are used to derive per-channel encryption keys. Per-channel keys are used encrypt event data on encrypted channels.
      *                         debug - debug mode
      *                         curl_options - wrapper for curl_setopt, more here: http://php.net/manual/en/function.curl-setopt.php
      *                         notification_host - host to connect to for native notifications.

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -56,7 +56,7 @@ class Pusher implements LoggerAwareInterface
      *                         encrypted - deprecated; renamed to `useTLS`.
      *                         cluster - cluster name to connect to.
      *                         encryption_master_key - a 32 char long key. This key, along with the channel name, are used to derive per-channel encryption keys. Per-channel keys are used encrypt event data on encrypted channels.
-     *                         debug - debug mode
+     *                         debug - (default `false`) if `true`, every `trigger()` and `triggerBatch()` call will return a `$response` object, useful for logging/inspection purposes.
      *                         curl_options - wrapper for curl_setopt, more here: http://php.net/manual/en/function.curl-setopt.php
      *                         notification_host - host to connect to for native notifications.
      *                         notification_scheme - scheme for the notification_host.
@@ -547,12 +547,12 @@ class Pusher implements LoggerAwareInterface
 
         $response = $this->exec_curl($ch);
 
-        if ($response['status'] === 200 && $debug === false) {
-            return true;
-        }
-
         if ($debug === true || $this->settings['debug'] === true) {
             return $response;
+        }
+
+        if ($response['status'] === 200) {
+            return true;
         }
 
         return false;
@@ -598,12 +598,12 @@ class Pusher implements LoggerAwareInterface
 
         $response = $this->exec_curl($ch);
 
-        if ($response['status'] === 200 && $debug === false) {
-            return true;
-        }
-
         if ($debug === true || $this->settings['debug'] === true) {
             return $response;
+        }
+
+        if ($response['status'] === 200) {
+            return true;
         }
 
         return false;

--- a/tests/acceptance/triggerBatchTest.php
+++ b/tests/acceptance/triggerBatchTest.php
@@ -9,7 +9,7 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
             PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET and
             PUSHERAPP_APPID keys.');
         } else {
-            $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, true, PUSHERAPP_HOST);
+            $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, false, PUSHERAPP_HOST);
             $this->pusher->setLogger(new TestLogger());
         }
     }

--- a/tests/acceptance/triggerTest.php
+++ b/tests/acceptance/triggerTest.php
@@ -87,15 +87,15 @@ class PusherPushTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-    * @expectedException \Pusher\PusherException
-    */
+     * @expectedException \Pusher\PusherException
+     */
     public function test_triggering_event_on_multiple_channels_with_encrypted_channel_present_error()
     {
         $options = array('encryption_master_key' => 'cAzRH3W9FZM3iXqSNIGtKztwNuCz9xMV');
         $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, $options, PUSHERAPP_HOST);
 
         $data = array('event_name' => 'event_data');
-        $channels = array('my-chan-ceppaio','private-encrypted-ceppaio');
+        $channels = array('my-chan-ceppaio', 'private-encrypted-ceppaio');
         $response = $this->pusher->trigger($channels, 'my_event', $data);
     }
 }

--- a/tests/acceptance/triggerTest.php
+++ b/tests/acceptance/triggerTest.php
@@ -73,4 +73,29 @@ class PusherPushTest extends PHPUnit\Framework\TestCase
 
         $this->assertTrue($response);
     }
+
+    public function test_triggering_event_on_private_encrypted_channel_success()
+    {
+        $options = array('encryption_master_key' => 'cAzRH3W9FZM3iXqSNIGtKztwNuCz9xMV');
+        $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, $options, PUSHERAPP_HOST);
+
+        $data = array('event_name' => 'event_data');
+        $channels = array('private-encrypted-ceppaio');
+        $response = $this->pusher->trigger($channels, 'my_event', $data);
+
+        $this->assertTrue($response);
+    }
+
+    /**
+    * @expectedException \Pusher\PusherException
+    */
+    public function test_triggering_event_on_multiple_channels_with_encrypted_channel_present_error()
+    {
+        $options = array('encryption_master_key' => 'cAzRH3W9FZM3iXqSNIGtKztwNuCz9xMV');
+        $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, $options, PUSHERAPP_HOST);
+
+        $data = array('event_name' => 'event_data');
+        $channels = array('my-chan-ceppaio','private-encrypted-ceppaio');
+        $response = $this->pusher->trigger($channels, 'my_event', $data);
+    }
 }

--- a/tests/acceptance/triggerTest.php
+++ b/tests/acceptance/triggerTest.php
@@ -9,7 +9,7 @@ class PusherPushTest extends PHPUnit\Framework\TestCase
             PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET and
             PUSHERAPP_APPID keys.');
         } else {
-            $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, true, PUSHERAPP_HOST);
+            $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, false, PUSHERAPP_HOST);
             $this->pusher->setLogger(new TestLogger());
         }
     }


### PR DESCRIPTION
- It fixes the behaviour of the `trigger` method introducing checks on mixed encrypted and non-encrypted channels specification
- It adds tests verifying the correct behaviour of `trigger`