### PR TITLE
Fix undefined socket_id PHP Notice

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -573,7 +573,9 @@ class Pusher implements LoggerAwareInterface
     {
         foreach ($batch as $key => $event) {
             $this->validate_channel($event['channel']);
-            $this->validate_socket_id($event['socket_id']);
+            if (isset($event['socket_id'])) {
+              $this->validate_socket_id($event['socket_id']);
+            }
 
             $data = $event['data'];
             if (!is_string($data)) {

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -574,7 +574,7 @@ class Pusher implements LoggerAwareInterface
         foreach ($batch as $key => $event) {
             $this->validate_channel($event['channel']);
             if (isset($event['socket_id'])) {
-              $this->validate_socket_id($event['socket_id']);
+                $this->validate_socket_id($event['socket_id']);
             }
 
             $data = $event['data'];


### PR DESCRIPTION
This PR aims to fix #200 by ensuring `socket_id` key exists in the `$event` Array before checking its validity.