### PR TITLE
Depend on the same versions of php and hhvm that we test against

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "keywords": ["php-pusher-server", "pusher", "rest", "realtime", "real-time", "real time", "messaging", "push", "trigger", "publish", "events"],
     "license": "MIT",
     "require": {
-        "php": "^5.4 || ^7.0",
+        "php": ">=5.4 <7.3",
+        "hhvm": "^3.24",
         "ext-curl": "*",
         "psr/log": "^1.0",
         "paragonie/sodium_compat": "^1.6"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4 <7.3",
-        "hhvm": "^3.24",
         "ext-curl": "*",
         "psr/log": "^1.0",
         "paragonie/sodium_compat": "^1.6"


### PR DESCRIPTION
Synchonrises the versions of php and hhvm that this library is
compatible with in composer.json with the versions we are testing
against in .travis.yml.

FYI these are "[platform package](https://getcomposer.org/doc/01-basic-usage.md#platform-packages)" dependencies in the composer.json.