### PR TITLE
Add get_users_info method

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,13 @@ var_dump($subscription_counts);
 ### Get user information from a presence channel
 
 ```php
+$results = $pusher->get_users_info( 'presence-channel-name' );
+$users_count = count($results->users); // $users is an Array
+```
+
+This can also be achieved using the generic `pusher->get` function:
+
+```php
 $response = $pusher->get( '/channels/presence-channel-name/users' )
 ```
 

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -663,6 +663,26 @@ class Pusher implements LoggerAwareInterface
     }
 
     /**
+     * Fetch user ids currently subscribed to a presence channel.
+     *
+     * @param string $channel The name of the channel
+     *
+     * @throws PusherException Throws exception if curl wasn't initialized correctly
+     *
+     * @return array|bool
+     */
+    public function get_users_info($channel)
+    {
+        $response = $this->get('/channels/'.$channel.'/users');
+
+        if ($response['status'] === 200) {
+            return json_decode($response['body']);
+        }
+
+        return false;
+    }
+
+    /**
      * GET arbitrary REST API resource using a synchronous http client.
      * All request signing is handled automatically.
      *

--- a/tests/acceptance/channelQueryTest.php
+++ b/tests/acceptance/channelQueryTest.php
@@ -67,6 +67,15 @@ class PusherChannelQueryTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(1, count($channels), 'channels have a single test-channel present. For this test to pass you must have the "Getting Started" page open on the dashboard for the app you are testing against');
     }
 
+    public function testUsersInfo()
+    {
+        $response = $this->pusher->get_users_info('presence-channel-test');
+
+        // print_r( $response );
+
+        $this->assertObjectHasAttribute('users', $response, 'class has users attribute');
+    }
+
     public function test_providing_info_parameter_with_prefix_query_fails_for_public_channel()
     {
         $options = array(


### PR DESCRIPTION
This was the only method in the HTTP that did not have a
corresponding higher-level method in this SDK.

Resolves: https://github.com/pusher/pusher-http-php/issues/153

The method name was inspired by
[the Python library](https://github.com/pusher/pusher-http-python/blob/master/pusher/pusher_client.py#L172),
and prefixed with `get` to make it consistent with other methods
in this library.

TODO

- [ ] Update https://pusher.com/docs/server_api_guide/interact_rest_api#presence-users