### PR TITLE
Drop php 5 and 7.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,15 @@
 language: php
 matrix:
   include:
-  - php: 5.4
-    env: INSTALL_LIBSODIUM=true
-  - php: 5.4
-    env: INSTALL_LIBSODIUM=false
-  - php: 5.5
-    env: INSTALL_LIBSODIUM=true
-  - php: 5.6
-    env: INSTALL_LIBSODIUM=true
-  - php: 7.0
-    env: INSTALL_LIBSODIUM=true
   - php: 7.1
     env: INSTALL_LIBSODIUM=true
+  # Check tests still work without libsodium install (the tests shouldn't run)
+  - php: 7.1
+    env: INSTALL_LIBSODIUM=false
+  # PHP >=7.2 include libsodium in the standard library
   - php: 7.2
     env: INSTALL_LIBSODIUM=false
   - php: 7.3
-    env: INSTALL_LIBSODIUM=false
-  - php: hhvm-3.24
     env: INSTALL_LIBSODIUM=false
 dist: trusty
 install: ./scripts/travis-install.sh

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Or you can clone or download the library files.
 
 This library depends on PHP modules for cURL and JSON. See [cURL module installation instructions](http://php.net/manual/en/curl.installation.php) and [JSON module installation instructions](http://php.net/manual/en/json.installation.php).
 
+## PHP support
+
+We support the versions of PHP that have "Security Support" in https://php.net/supported-versions.php.
 
 ## Pusher constructor
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "paragonie/sodium_compat": "^1.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.7"
+        "phpunit/phpunit": "^7.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["php-pusher-server", "pusher", "rest", "realtime", "real-time", "real time", "messaging", "push", "trigger", "publish", "events"],
     "license": "MIT",
     "require": {
-        "php": ">=5.4 <7.4",
+        "php": ">=7.1 <7.4",
         "ext-curl": "*",
         "psr/log": "^1.0",
         "paragonie/sodium_compat": "^1.6"

--- a/scripts/travis-install.sh
+++ b/scripts/travis-install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
+curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-7.5.9.phar
 composer install --no-interaction --prefer-source
 
 if [ $INSTALL_LIBSODIUM = true ]; then

--- a/scripts/travis-install.sh
+++ b/scripts/travis-install.sh
@@ -8,9 +8,5 @@ composer install --no-interaction --prefer-source
 if [ $INSTALL_LIBSODIUM = true ]; then
   sudo add-apt-repository ppa:ondrej/php -y
   sudo apt-get update && sudo apt-get install libsodium-dev -y
-  if [ $TRAVIS_PHP_VERSION == '5.4' ] || [ $TRAVIS_PHP_VERSION == '5.5' ] || [ $TRAVIS_PHP_VERSION == '5.6' ]; then
-    pecl install libsodium-1.0.7
-  else
-    pecl install libsodium-2.0.11
-  fi
+  pecl install libsodium-2.0.11
 fi


### PR DESCRIPTION
Resolves https://github.com/pusher/pusher-http-php/issues/206, which explains the motivation for this. I've also upgraded phpunit which resolves a warning described in the same issue.

We have a new policy which is to support PHP versions with security support in https://php.net/supported-versions.php; this is now documented in the README.

I also dropped support for the last version of HHVM we were supporting (3.24). This version of HHVM is no longer supported.

> As 3.24 is supported though 2018-12-17, this means that support will end at roughly the same time as PHP5 itself is scheduled to become unsupported (2018-12-31).

https://hhvm.com/blog/2018/01/16/hhvm-3.24.html