### PR TITLE
More prominent logger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,38 @@ becoming unwieldy. However, backwards compatibility has been maintained.*
 
 *Note: The `host` option overrides the `cluster` option!*
 
+## Logging configuration
+
+The best way to debug your applications interaction with server is to set a logger for the library so you can see the internal workings within the library and interactions with the Channels service.
+
+### PSR-3 Support
+
+The recommended approach of logging is to use a [PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md) compliant logger implementing `Psr\Log\LoggerInterface`. The `Pusher` object implements `Psr\Log\LoggerAwareInterface`, meaning you call `setLogger(LoggerInterface $logger)` to set the logger instance.
+
+```php
+// where $logger implements `LoggerInterface`
+
+$pusher->setLogger($logger);
+```
+
+### Custom Logger (deprecated)
+
+> **Warning**: Using `Pusher::set_logger()` and a custom object implementing `log()` is now deprecated and will be removed in the future. Please use a PSR-3 compliant logger.
+
+You set up logging by passing an object with a `log` function to the `pusher->set_logger` function:
+
+```php
+class MyLogger {
+  public function log( $msg ) {
+    print_r( $msg . "\n" );
+  }
+}
+
+$pusher->set_logger( new MyLogger() );
+```
+
+If you use the above example in code executed from the console/terminal the debug information will be output there. If you use this within a web app then the output will appear within the generated app output e.g. HTML.
+
 ## Publishing/Triggering events
 
 To trigger an event on one or more channels use the `trigger` function.
@@ -359,38 +391,6 @@ $response = $pusher->get( '/channels' );
 $http_status_code = $response[ 'status' ];
 $result = $response[ 'result' ];
 ```
-
-## Debugging & Logging
-
-The best way to debug your applications interaction with server is to set a logger for the library so you can see the internal workings within the library and interactions with the Channels service.
-
-### PSR-3 Support
-
-The recommended approach of logging is to use a [PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md) compliant logger implementing `Psr\Log\LoggerInterface`. The `Pusher` object implements `Psr\Log\LoggerAwareInterface`, meaning you call `setLogger(LoggerInterface $logger)` to set the logger instance.
-
-```php
-// where $logger implements `LoggerInterface`
-
-$pusher->setLogger($logger);
-```
-
-### Custom Logger (deprecated)
-
-> **Warning**: Using `Pusher::set_logger()` and a custom object implementing `log()` is now deprecated and will be removed in the future. Please use a PSR-3 compliant logger.
-
-You set up logging by passing an object with a `log` function to the `pusher->set_logger` function:
-
-```php
-class MyLogger {
-  public function log( $msg ) {
-    print_r( $msg . "\n" );
-  }
-}
-
-$pusher->set_logger( new MyLogger() );
-```
-
-If you use the above example in code executed from the console/terminal the debug information will be output there. If you use this within a web app then the output will appear within the generated app output e.g. HTML.
 
 ## Running the tests
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ becoming unwieldy. However, backwards compatibility has been maintained.*
 
 ## Logging configuration
 
-The best way to debug your applications interaction with server is to set a logger for the library so you can see the internal workings within the library and interactions with the Channels service.
+It is strongly recommended that you configure a logger.
+By default errors are easy to miss because the library will only return `false` if anything fails.
 
 ### PSR-3 Support
 


### PR DESCRIPTION
This is because the SDK swallows errors by default (just returning
`false`). Both when developing, and in production too, we expect
almost all users will want to configure a logger, so let's ask
them to do this early on in the docs.

The answer to a number of issues has been "configure a logger",
e.g. https://github.com/pusher/pusher-http-php/issues/231#issuecomment-546042411.
I'm hoping this change will reduce the frequency of these.

It's only the first paragraph I reworded.