### PR TITLE
Add curl error in the response array.

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -389,8 +389,14 @@ class Pusher implements LoggerAwareInterface
         $response['body'] = curl_exec($ch);
         $response['status'] = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
+        // If there's a curl error, include it in the response object to help with debugging.
+        $curl_error = curl_error($ch);
+        if (strlen($curl_error) > 0) {
+            $response['curl_error'] = $curl_error;
+        }
+
         if ($response['body'] === false) {
-            $this->log('exec_curl error: {error}', array('error' => curl_error($ch)), LogLevel::ERROR);
+            $this->log('exec_curl error: {error}', array('error' => $curl_error), LogLevel::ERROR);
         } elseif ($response['status'] < 200 || 400 <= $response['status']) {
             $this->log('exec_curl {status} error from server: {body}', $response, LogLevel::ERROR);
         } else {


### PR DESCRIPTION
I spent 4+ hours debugging why I'm getting a `body => false` and `status => 0` response using Laravel. It turns out that I had a problem with my DNS and I only figured it out after using `dd` to get the curl error in the package src files.

It would have been much faster to debug if the curl error was sent as a part of the response. And that's exactly what this PR is about. Not wanting anyone to spend hours debugging a weird error like a DNS problem, this PR will simply send the curl error in the response object if it exists.

Hopefully that's a helpful PR :)