### PR TITLE
Only test pushes to the master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master, main]
 
 jobs:
   test:


### PR DESCRIPTION
Other pushes are covered by `pull_request`

Motivation in https://github.com/pusher/pusher-http-go/pull/75#discussion_r570362582.