### PR TITLE
Throw ApiErrorException instead of returning false

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,6 @@ The fourth parameter is an `$options` array. The additional options are:
 * `encryption_master_key` - a 32 char long key. This key, along with the
   channel name, are used to derive per-channel encryption keys. Per-channel
   keys are used encrypt event data on encrypted channels.
-* `debug` - (default `false`) if `true`, every `trigger()` and `triggerBatch()`
-  call will return a `$response` object (e.g.): `Array ([body] => {} [status]
-  => 200)`
 
 For example, by default calls will be made over a non-TLS connection. To change
 this to make calls over HTTPS use:

--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ maintained.
 
 ## Logging configuration
 
-It is strongly recommended that you configure a logger.  By default errors are
-easy to miss because the library will only return `false` if anything fails.
+It is strongly recommended that you configure a logger.
 
 ### PSR-3 Support
 
@@ -200,7 +199,7 @@ If your data is already encoded in JSON format, you can avoid a second encoding
 step by setting the sixth argument true, like so:
 
 ```php
-$pusher->trigger('my-channel', 'event', 'data', null, false, true)
+$pusher->trigger('my-channel', 'event', 'data', null, true)
 ```
 
 ## Authenticating Private channels

--- a/src/ApiErrorException.php
+++ b/src/ApiErrorException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Pusher;
+
+/**
+ * HTTP error responses.
+ * getCode() will return the response HTTP status code,
+ * and getMessage() will return the response body.
+ */
+class ApiErrorException extends PusherException
+{
+    /**
+     * Returns the string representation of the exception.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return "(Status {$this->getCode()}) {$this->getMessage()}";
+    }
+}

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -29,7 +29,6 @@ class Pusher implements LoggerAwareInterface, PusherInterface
         'port'                  => 80,
         'path'                  => '',
         'timeout'               => 30,
-        'debug'                 => false,
         'curl_options'          => array(),
     );
 
@@ -40,14 +39,12 @@ class Pusher implements LoggerAwareInterface, PusherInterface
 
     /**
      * Initializes a new Pusher instance with key, secret, app ID and channel.
-     * You can optionally turn on debugging for all requests by setting debug to true.
      *
      * @param string $auth_key
      * @param string $secret
      * @param int    $app_id
      * @param array  $options  [optional]
      *                         Options to configure the Pusher instance.
-     *                         Was previously a debug flag. Legacy support for this exists if a boolean is passed.
      *                         scheme - e.g. http or https
      *                         host - the host e.g. api.pusherapp.com. No trailing forward slash.
      *                         port - the http port
@@ -57,7 +54,6 @@ class Pusher implements LoggerAwareInterface, PusherInterface
      *                         cluster - cluster name to connect to.
      *                         encryption_master_key - deprecated; use `encryption_master_key_base64`
      *                         encryption_master_key_base64 - a 32 byte key, encoded as base64. This key, along with the channel name, are used to derive per-channel encryption keys. Per-channel keys are used to encrypt event data on encrypted channels.
-     *                         debug - (default `false`) if `true`, every `trigger()` and `triggerBatch()` call will return a `$response` object, useful for logging/inspection purposes.
      *                         curl_options - wrapper for curl_setopt, more here: http://php.net/manual/en/function.curl-setopt.php
      * @param string $host     [optional] - deprecated
      * @param int    $port     [optional] - deprecated
@@ -68,13 +64,6 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     public function __construct($auth_key, $secret, $app_id, $options = array(), $host = null, $port = null, $timeout = null)
     {
         $this->check_compatibility();
-
-        /* Start backward compatibility with old constructor **/
-        if (is_bool($options) === true) {
-            $options = array(
-                'debug' => $options,
-            );
-        }
 
         if (!is_null($host)) {
             $match = null;

--- a/src/PusherInterface.php
+++ b/src/PusherInterface.php
@@ -30,27 +30,27 @@ interface PusherInterface
      * @param string       $event
      * @param mixed        $data            Event data
      * @param string|null  $socket_id       [optional]
-     * @param bool         $debug           [optional]
      * @param bool         $already_encoded [optional]
      *
-     * @throws PusherException Throws exception if $channels is an array of size 101 or above or $socket_id is invalid
+     * @throws PusherException   Throws exception if $channels is an array of size 101 or above or $socket_id is invalid
+     * @throws ApiErrorException Throws ApiErrorException if the Channels HTTP API responds with an error
      *
-     * @return bool|array
+     * @return object
      */
-    public function trigger($channels, $event, $data, $socket_id = null, $debug = false, $already_encoded = false);
+    public function trigger($channels, $event, $data, $socket_id = null, $already_encoded = false);
 
     /**
      * Trigger multiple events at the same time.
      *
      * @param array $batch           [optional] An array of events to send
-     * @param bool  $debug           [optional]
      * @param bool  $already_encoded [optional]
      *
-     * @throws PusherException Throws exception if curl wasn't initialized correctly
+     * @throws PusherException   Throws exception if curl wasn't initialized correctly
+     * @throws ApiErrorException Throws ApiErrorException if the Channels HTTP API responds with an error
      *
-     * @return array|bool|string
+     * @return object
      */
-    public function triggerBatch($batch = array(), $debug = false, $already_encoded = false);
+    public function triggerBatch($batch = array(), $already_encoded = false);
 
     /**
      * Fetch channel information for a specific channel.
@@ -58,9 +58,10 @@ interface PusherInterface
      * @param string $channel The name of the channel
      * @param array  $params  Additional parameters for the query e.g. $params = array( 'info' => 'connection_count' )
      *
-     * @throws PusherException If $channel is invalid or if curl wasn't initialized correctly
+     * @throws PusherException   If $channel is invalid or if curl wasn't initialized correctly
+     * @throws ApiErrorException Throws ApiErrorException if the Channels HTTP API responds with an error
      *
-     * @return bool|object
+     * @return object
      */
     public function get_channel_info($channel, $params = array());
 
@@ -69,9 +70,10 @@ interface PusherInterface
      *
      * @param array $params Additional parameters for the query e.g. $params = array( 'info' => 'connection_count' )
      *
-     * @throws PusherException Throws exception if curl wasn't initialized correctly
+     * @throws PusherException   Throws exception if curl wasn't initialized correctly
+     * @throws ApiErrorException Throws ApiErrorException if the Channels HTTP API responds with an error
      *
-     * @return array|bool
+     * @return object
      */
     public function get_channels($params = array());
 
@@ -80,9 +82,10 @@ interface PusherInterface
      *
      * @param string $channel The name of the channel
      *
-     * @throws PusherException Throws exception if curl wasn't initialized correctly
+     * @throws PusherException   Throws exception if curl wasn't initialized correctly
+     * @throws ApiErrorException Throws ApiErrorException if the Channels HTTP API responds with an error
      *
-     * @return array|bool
+     * @return object
      */
     public function get_users_info($channel);
 
@@ -92,10 +95,12 @@ interface PusherInterface
      *
      * @param string $path   Path excluding /apps/APP_ID
      * @param array  $params API params (see http://pusher.com/docs/rest_api)
+     * @param bool   $associative When true, return the response body as an associative array, else return as an object
      *
-     * @throws PusherException Throws exception if curl wasn't initialized correctly
+     * @throws PusherException   Throws exception if curl wasn't initialized correctly
+     * @throws ApiErrorException Throws ApiErrorException if the Channels HTTP API responds with an error
      *
-     * @return array|bool See Pusher API docs
+     * @return mixed See Pusher API docs
      */
     public function get($path, $params = array());
 

--- a/tests/acceptance/channelQueryTest.php
+++ b/tests/acceptance/channelQueryTest.php
@@ -4,7 +4,7 @@ class PusherChannelQueryTest extends PHPUnit\Framework\TestCase
 {
     protected function setUp(): void
     {
-        $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, true, PUSHERAPP_HOST);
+        $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, array(), PUSHERAPP_HOST);
         $this->pusher->setLogger(new TestLogger());
     }
 

--- a/tests/acceptance/channelQueryTest.php
+++ b/tests/acceptance/channelQueryTest.php
@@ -10,11 +10,11 @@ class PusherChannelQueryTest extends PHPUnit\Framework\TestCase
 
     public function testChannelInfo()
     {
-        $response = $this->pusher->get_channel_info('channel-test');
+        $result = $this->pusher->get_channel_info('channel-test');
 
-        //print_r( $response );
+        //print_r( $result );
 
-        $this->assertObjectHasAttribute('occupied', $response, 'class has occupied attribute');
+        $this->assertObjectHasAttribute('occupied', $result, 'class has occupied attribute');
     }
 
     public function testChannelList()
@@ -69,31 +69,27 @@ class PusherChannelQueryTest extends PHPUnit\Framework\TestCase
 
     public function testUsersInfo()
     {
-        $response = $this->pusher->get_users_info('presence-channel-test');
+        $result = $this->pusher->get_users_info('presence-channel-test');
 
-        // print_r( $response );
+        // print_r( $result );
 
-        $this->assertObjectHasAttribute('users', $response, 'class has users attribute');
+        $this->assertObjectHasAttribute('users', $result, 'class has users attribute');
     }
 
     public function testProvidingInfoParameterWithPrefixQueryFailsForPublicChannel()
     {
+        $this->expectException(\Pusher\ApiErrorException::class);
+
         $options = array(
             'filter_by_prefix' => 'test_',
             'info'             => 'user_count',
         );
         $result = $this->pusher->get_channels($options);
-
-        $this->assertFalse($result, 'query should fail');
     }
 
     public function testChannelListUsingGenericGet()
     {
-        $response = $this->pusher->get('/channels');
-
-        $this->assertEquals($response['status'], 200);
-
-        $result = $response['result'];
+        $result = $this->pusher->get('/channels', array(), true);
 
         $channels = $result['channels'];
 
@@ -106,11 +102,7 @@ class PusherChannelQueryTest extends PHPUnit\Framework\TestCase
 
     public function testChannelListUsingGenericGetAndPrefixParam()
     {
-        $response = $this->pusher->get('/channels', array('filter_by_prefix' => 'my-'));
-
-        $this->assertEquals($response['status'], 200);
-
-        $result = $response['result'];
+        $result = $this->pusher->get('/channels', array('filter_by_prefix' => 'my-'), true);
 
         $channels = $result['channels'];
 
@@ -123,12 +115,8 @@ class PusherChannelQueryTest extends PHPUnit\Framework\TestCase
 
     public function testSingleChannelInfoUsingGenericGet()
     {
-        $response = $this->pusher->get('/channels/channel-test');
+        $result = $this->pusher->get('/channels/channel-test');
 
-        $this->assertEquals($response['status'], 200);
-
-        $result = $response['result'];
-
-        $this->assertArrayHasKey('occupied', $result, 'class has occupied attribute');
+        $this->assertObjectHasAttribute('occupied', $result, 'class has occupied attribute');
     }
 }

--- a/tests/acceptance/triggerBatchTest.php
+++ b/tests/acceptance/triggerBatchTest.php
@@ -9,7 +9,7 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
             PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET and
             PUSHERAPP_APPID keys.');
         } else {
-            $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, false, PUSHERAPP_HOST);
+            $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, array(), PUSHERAPP_HOST);
             $this->pusher->setLogger(new TestLogger());
         }
     }

--- a/tests/acceptance/triggerBatchTest.php
+++ b/tests/acceptance/triggerBatchTest.php
@@ -23,8 +23,8 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
     {
         $batch = array();
         $batch[] = array('channel' => 'test_channel', 'name' => 'my_event', 'data' => array('my' => 'data'));
-        $string_trigger = $this->pusher->triggerBatch($batch);
-        $this->assertTrue($string_trigger, 'Trigger with string payload');
+        $result = $this->pusher->triggerBatch($batch);
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testTLSPush()
@@ -38,8 +38,8 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
 
         $batch = array();
         $batch[] = array('channel' => 'test_channel', 'name' => 'my_event', 'data' => array('my' => 'data'));
-        $string_trigger = $pc->triggerBatch($batch);
-        $this->assertTrue($string_trigger, 'Trigger with string payload');
+        $result = $pc->triggerBatch($batch);
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testTriggerBatchNonEncryptedEventsWithObjectPayloads()
@@ -54,8 +54,8 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
         $batch = array();
         $batch[] = array('channel' => 'test_channel', 'name' => 'my_event', 'data' => array('my' => 'data'));
         $batch[] = array('channel' => 'mio_canale', 'name' => 'my_event2', 'data' => array('my' => 'data2'));
-        $string_trigger = $pc->triggerBatch($batch);
-        $this->assertTrue($string_trigger, 'Failed to triggerBatch Multiple Events');
+        $result = $pc->triggerBatch($batch);
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testTriggerBatchWithSingleEvent()
@@ -69,8 +69,8 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
 
         $batch = array();
         $batch[] = array('channel' => 'test_channel', 'name' => 'my_event', 'data' => 'test-string');
-        $string_trigger = $pc->triggerBatch($batch);
-        $this->assertTrue($string_trigger, 'Failed to triggerBatch Multiple Events');
+        $result = $pc->triggerBatch($batch);
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testTriggerBatchWithMultipleNonEncryptedEventsWithStringPayloads()
@@ -85,8 +85,8 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
         $batch = array();
         $batch[] = array('channel' => 'test_channel', 'name' => 'my_event', 'data' => 'test-string');
         $batch[] = array('channel' => 'test_channel2', 'name' => 'my_event2', 'data' => 'test-string2');
-        $string_trigger = $pc->triggerBatch($batch);
-        $this->assertTrue($string_trigger, 'Failed to triggerBatch Multiple Events');
+        $result = $pc->triggerBatch($batch);
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testTriggerBatchWithMultipleCombinationsofStringAndObjectPayloads()
@@ -101,8 +101,8 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
         $batch = array();
         $batch[] = array('channel' => 'test_channel', 'name' => 'my_event', 'data' => 'test-string');
         $batch[] = array('channel' => 'test_channel2', 'name' => 'my_event2', 'data' => array('my' => 'data2'));
-        $string_trigger = $pc->triggerBatch($batch);
-        $this->assertTrue($string_trigger, 'Failed to triggerBatch Multiple Events');
+        $result = $pc->triggerBatch($batch);
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testTriggerBatchWithWithEncryptedEventSuccess()
@@ -117,8 +117,8 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
 
         $batch = array();
         $batch[] = array('channel' => 'private-encrypted-test_channel', 'name' => 'my_event', 'data' => 'test-string');
-        $string_trigger = $pc->triggerBatch($batch);
-        $this->assertTrue($string_trigger, 'Failed to triggerBatch Multiple Events');
+        $result = $pc->triggerBatch($batch);
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testTriggerBatchWithMultipleEncryptedEventsSuccess()
@@ -134,8 +134,8 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
         $batch = array();
         $batch[] = array('channel' => 'test_channel', 'name' => 'my_event', 'data' => 'test-string');
         $batch[] = array('channel' => 'private-encrypted-test_channel2', 'name' => 'my_event2', 'data' => 'test-string2');
-        $string_trigger = $pc->triggerBatch($batch);
-        $this->assertTrue($string_trigger, 'Failed to triggerBatch Multiple Events');
+        $result = $pc->triggerBatch($batch);
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testTriggerBatchWithMultipleCombinationsofStringsAndObjectsWithEncryptedEventSuccess()
@@ -151,8 +151,8 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
         $batch = array();
         $batch[] = array('channel' => 'test_channel', 'name' => 'my_event', 'data' => 'secret-string');
         $batch[] = array('channel' => 'private-encrypted-test_channel2', 'name' => 'my_event2', 'data' => array('my' => 'data2'));
-        $string_trigger = $pc->triggerBatch($batch);
-        $this->assertTrue($string_trigger, 'Failed to triggerBatch Multiple Events');
+        $result = $pc->triggerBatch($batch);
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testTriggerBatchMultipleEventsWithEncryptedEventWithoutEncryptionMasterKeyError()
@@ -185,28 +185,32 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
         $batch = array();
         $batch[] = array('channel' => 'my_test_chan', 'name' => 'my_event', 'data' => array('my' => 'data'));
         $batch[] = array('channel' => 'private-encrypted-ceppaio', 'name' => 'my_private_encrypted_event', 'data' => array('my' => 'to_be_encrypted_data_shhhht'));
-        $string_trigger = $pc->triggerBatch($batch);
-        $this->assertTrue($string_trigger, 'Failed to triggerBatch Multiple Events');
+        $result = $pc->triggerBatch($batch);
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testSendingOver10kBMessageReturns413()
     {
+        $this->expectException(\Pusher\ApiErrorException::class);
+        $this->expectExceptionMessage('content of this event');
+        $this->expectExceptionCode('413');
+
         $data = str_pad('', 11 * 1024, 'a');
         $batch = array();
         $batch[] = array('channel' => 'test_channel', 'name' => 'my_event', 'data' => $data);
-        $response = $this->pusher->triggerBatch($batch, true, true);
-        $this->assertContains('content of this event', $response['body']);
-        $this->assertEquals(413, $response['status'], '413 HTTP status response expected');
+        $this->pusher->triggerBatch($batch, true, true);
     }
 
     public function testSendingOver10messagesReturns400()
     {
+        $this->expectException(\Pusher\ApiErrorException::class);
+        $this->expectExceptionMessage('Batch too large');
+        $this->expectExceptionCode('400');
+
         $batch = array();
         foreach (range(1, 11) as $i) {
             $batch[] = array('channel' => 'test_channel', 'name' => 'my_event', 'data' => array('index' => $i));
         }
-        $response = $this->pusher->triggerBatch($batch, true, false);
-        $this->assertContains('Batch too large', $response['body']);
-        $this->assertEquals(400, $response['status'], '400 HTTP status response expected');
+        $this->pusher->triggerBatch($batch, true, false);
     }
 }

--- a/tests/acceptance/triggerTest.php
+++ b/tests/acceptance/triggerTest.php
@@ -9,7 +9,7 @@ class PusherPushTest extends PHPUnit\Framework\TestCase
             PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET and
             PUSHERAPP_APPID keys.');
         } else {
-            $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, false, PUSHERAPP_HOST);
+            $this->pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, array(), PUSHERAPP_HOST);
             $this->pusher->setLogger(new TestLogger());
         }
     }

--- a/tests/acceptance/triggerTest.php
+++ b/tests/acceptance/triggerTest.php
@@ -21,14 +21,14 @@ class PusherPushTest extends PHPUnit\Framework\TestCase
 
     public function testStringPush()
     {
-        $string_trigger = $this->pusher->trigger('test_channel', 'my_event', 'Test string');
-        $this->assertTrue($string_trigger, 'Trigger with string payload');
+        $result = $this->pusher->trigger('test_channel', 'my_event', 'Test string');
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testArrayPush()
     {
-        $structure_trigger = $this->pusher->trigger('test_channel', 'my_event', array('test' => 1));
-        $this->assertTrue($structure_trigger, 'Trigger with structured payload');
+        $result = $this->pusher->trigger('test_channel', 'my_event', array('test' => 1));
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testTLSPush()
@@ -40,16 +40,18 @@ class PusherPushTest extends PHPUnit\Framework\TestCase
         $pusher = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, $options);
         $pusher->setLogger(new TestLogger());
 
-        $structure_trigger = $pusher->trigger('test_channel', 'my_event', array('encrypted' => 1));
-        $this->assertTrue($structure_trigger, 'Trigger with over TLS connection');
+        $result = $pusher->trigger('test_channel', 'my_event', array('encrypted' => 1));
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testSendingOver10kBMessageReturns413()
     {
+        $this->expectException(\Pusher\ApiErrorException::class);
+        $this->expectExceptionCode('413');
+
         $data = str_pad('', 11 * 1024, 'a');
         echo  'sending data of size: '.mb_strlen($data, '8bit');
-        $response = $this->pusher->trigger('test_channel', 'my_event', $data, null, true);
-        $this->assertEquals(413, $response['status'], '413 HTTP status response expected');
+        $this->pusher->trigger('test_channel', 'my_event', $data, null, true);
     }
 
     public function testTriggeringEventOnOver100ChannelsThrowsException()
@@ -61,16 +63,15 @@ class PusherPushTest extends PHPUnit\Framework\TestCase
             $channels[] = ('channel-'.count($channels));
         }
         $data = array('event_name' => 'event_data');
-        $response = $this->pusher->trigger($channels, 'my_event', $data);
+        $this->pusher->trigger($channels, 'my_event', $data);
     }
 
     public function testTriggeringEventOnMultipleChannels()
     {
         $data = array('event_name' => 'event_data');
         $channels = array('test_channel_1', 'test_channel_2');
-        $response = $this->pusher->trigger($channels, 'my_event', $data);
-
-        $this->assertTrue($response);
+        $result = $this->pusher->trigger($channels, 'my_event', $data);
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testTriggeringEventOnPrivateEncryptedChannelSuccess()
@@ -80,9 +81,8 @@ class PusherPushTest extends PHPUnit\Framework\TestCase
 
         $data = array('event_name' => 'event_data');
         $channels = array('private-encrypted-ceppaio');
-        $response = $this->pusher->trigger($channels, 'my_event', $data);
-
-        $this->assertTrue($response);
+        $result = $this->pusher->trigger($channels, 'my_event', $data);
+        $this->assertEquals(new stdClass(), $result);
     }
 
     public function testTriggeringEventOnMultipleChannelsWithEncryptedChannelPresentError()
@@ -94,6 +94,6 @@ class PusherPushTest extends PHPUnit\Framework\TestCase
 
         $data = array('event_name' => 'event_data');
         $channels = array('my-chan-ceppaio', 'private-encrypted-ceppaio');
-        $response = $this->pusher->trigger($channels, 'my_event', $data);
+        $this->pusher->trigger($channels, 'my_event', $data);
     }
 }

--- a/tests/unit/authQueryStringTest.php
+++ b/tests/unit/authQueryStringTest.php
@@ -4,7 +4,7 @@ class PusherAuthQueryString extends PHPUnit\Framework\TestCase
 {
     protected function setUp(): void
     {
-        $this->pusher = new Pusher\Pusher('thisisaauthkey', 'thisisasecret', 1, true);
+        $this->pusher = new Pusher\Pusher('thisisaauthkey', 'thisisasecret', 1);
     }
 
     public function testArrayImplode()

--- a/tests/unit/channelInfoUnitTest.php
+++ b/tests/unit/channelInfoUnitTest.php
@@ -4,7 +4,7 @@ class PusherChannelInfoUnitTest extends PHPUnit\Framework\TestCase
 {
     protected function setUp(): void
     {
-        $this->pusher = new Pusher\Pusher('thisisaauthkey', 'thisisasecret', 1, true);
+        $this->pusher = new Pusher\Pusher('thisisaauthkey', 'thisisasecret', 1);
     }
 
     public function testTrailingColonChannelThrowsException()

--- a/tests/unit/pusherConstructorTest.php
+++ b/tests/unit/pusherConstructorTest.php
@@ -2,20 +2,12 @@
 
 class pusherConstructorTest extends PHPUnit\Framework\TestCase
 {
-    public function testDebugCanBeSetViaLegacyParameter()
-    {
-        $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', true);
-
-        $settings = $pusher->getSettings();
-        $this->assertEquals(true, $settings['debug']);
-    }
-
     public function testHostAndSchemeCanBeSetViaLegacyParameter()
     {
         $scheme = 'http';
         $host = 'test.com';
         $legacy_host = "$scheme://$host";
-        $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', false, $legacy_host);
+        $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', array(), $legacy_host);
 
         $settings = $pusher->getSettings();
         $this->assertEquals($scheme, $settings['scheme']);
@@ -25,7 +17,7 @@ class pusherConstructorTest extends PHPUnit\Framework\TestCase
     public function testLegacyHostParamWithNoSchemeCanBeUsedResultsInHostBeingUsedWithDefaultScheme()
     {
         $host = 'test.com';
-        $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', false, $host);
+        $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', array(), $host);
 
         $settings = $pusher->getSettings();
         $this->assertEquals($host, $settings['host']);
@@ -35,7 +27,7 @@ class pusherConstructorTest extends PHPUnit\Framework\TestCase
     {
         $host = 'https://test.com';
         $port = 90;
-        $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', false, $host, $port);
+        $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', array(), $host, $port);
 
         $settings = $pusher->getSettings();
         $this->assertEquals('https', $settings['scheme']);
@@ -45,7 +37,7 @@ class pusherConstructorTest extends PHPUnit\Framework\TestCase
     {
         $host = 'https://test.com';
         $port = 90;
-        $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', false, $host, $port);
+        $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', array(), $host, $port);
 
         $settings = $pusher->getSettings();
         $this->assertEquals($port, $settings['port']);
@@ -56,7 +48,7 @@ class pusherConstructorTest extends PHPUnit\Framework\TestCase
         $host = 'http://test.com';
         $port = 90;
         $timeout = 90;
-        $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', false, $host, $port, $timeout);
+        $pusher = new Pusher\Pusher('app_key', 'app_secret', 'app_id', array(), $host, $port, $timeout);
 
         $settings = $pusher->getSettings();
         $this->assertEquals($timeout, $settings['timeout']);

--- a/tests/unit/socketAuthTest.php
+++ b/tests/unit/socketAuthTest.php
@@ -4,7 +4,7 @@ class PusherSocketAuthTest extends PHPUnit\Framework\TestCase
 {
     protected function setUp(): void
     {
-        $this->pusher = new Pusher\Pusher('thisisaauthkey', 'thisisasecret', 1, true);
+        $this->pusher = new Pusher\Pusher('thisisaauthkey', 'thisisasecret', 1, array());
     }
 
     public function testObjectConstruct()

--- a/tests/unit/triggerUnitTest.php
+++ b/tests/unit/triggerUnitTest.php
@@ -72,14 +72,6 @@ class PusherTriggerUnitTest extends PHPUnit\Framework\TestCase
         $this->pusher->trigger('test_channel:', $this->eventName, $this->data, '1.1\n:');
     }
 
-    public function testNullSocketID()
-    {
-        // Check this does not throw an exception
-        $this->pusher->trigger('test_channel', $this->eventName, $this->data, null);
-
-        $this->assertTrue(true);
-    }
-
     public function testFalseSocketIDThrowsException()
     {
         $this->expectException(\Pusher\PusherException::class);

--- a/tests/unit/triggerUnitTest.php
+++ b/tests/unit/triggerUnitTest.php
@@ -4,7 +4,7 @@ class PusherTriggerUnitTest extends PHPUnit\Framework\TestCase
 {
     protected function setUp(): void
     {
-        $this->pusher = new Pusher\Pusher('thisisaauthkey', 'thisisasecret', 1, true);
+        $this->pusher = new Pusher\Pusher('thisisaauthkey', 'thisisasecret', 1);
         $this->eventName = 'test_event';
         $this->data = array();
     }

--- a/tests/unit/webhookTest.php
+++ b/tests/unit/webhookTest.php
@@ -5,7 +5,7 @@ class webhookTest extends PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $this->auth_key = 'thisisaauthkey';
-        $this->pusher = new Pusher\Pusher($this->auth_key, 'thisisasecret', 1, true);
+        $this->pusher = new Pusher\Pusher($this->auth_key, 'thisisasecret', 1);
     }
 
     public function testValidWebhookSignature()


### PR DESCRIPTION
Note this introduces a breaking change to all of the methods
that wrap API requests.

Advantages:

- Removes the need for the `debug` parameter to return the error
  message
- Makes it more obvious when requests fail. Previously a user
  would only see an error if they had enabled a logger.
- It's more idiomatic to throw exceptions than return `false`
  in modern PHP. For example the Stripe PHP SDK does it this way:
  https://github.com/stripe/stripe-php/blob/master/lib/Exception/ApiErrorException.php

Other related changes:
- The trigger methods now return an empty object rather than `true`
  on success. This more accurately reflects what the API returns.
- The `get` method now has an `$associative` parameter that controls
  how `json_decode` decodes the response body.
- The `get` method does not include the whole response from curl,
  but just the decoded response body.
- Renamed `$response` -> `$result` in some tests. I think this is more
  consistent with the name given to the root object in the response bodies.
- removed `PusherTriggerUnitTest::testNullSocketID` - this was hard to
  test now that the subject-under-test throws exceptions due to invalid
  credentials rather than just returning null. I think this case is sufficiently
  covered in the unit tests, so I removed it.

Resolves https://github.com/pusher/pusher-http-php/issues/229

TODO

- [x] Update https://pusher.com/docs (if necessary)