### PR TITLE
Support fetching channel info on trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,20 @@ $subscription_count = $result->channels['my-channel']->subscription_count;
 
 ```php
 $batch = array();
-$batch[] = array('channel' => 'my-channel', 'name' => 'my_event', 'data' => array('hello' => 'world'), 'info' => array('info' => 'subscription_count'));
-$batch[] = array('channel' => 'presence-my-channel', 'name' => 'my_event', 'data' => array('myname' => 'bob'), 'info' => array('info' => 'user_count,subscription_count'));
-$channels = $pusher->triggerBatch($batch);
-$subscription_count = count($result->channels['my-channel']->subscription_count);
-$user_count = count($result->channels['presence-my-channel']->user_count);
+$batch[] = array('channel' => 'my-channel', 'name' => 'my_event', 'data' => array('hello' => 'world'), 'info' => 'subscription_count');
+$batch[] = array('channel' => 'presence-my-channel', 'name' => 'my_event', 'data' => array('myname' => 'bob'), 'info' => 'user_count,subscription_count');
+$result = $pusher->triggerBatch($batch);
+
+foreach ($result->batch as $i => $attributes) {
+  echo "channel: {$batch[$i]['channel']}, name: {$batch[$i]['name']}";
+  if (isset($attributes->subscription_count)) {
+    echo ", subscription_count: {$attributes->subscription_count}";
+  }
+  if (isset($attributes->user_count)) {
+    echo ", user_count: {$attributes->user_count}";
+  }
+  echo PHP_EOL;
+}
 ```
 
 ### JSON format

--- a/README.md
+++ b/README.md
@@ -184,10 +184,37 @@ The output of this will be:
 
 In order to avoid duplicates you can optionally specify the sender's socket id
 while triggering an event
-([https://pusher.com/docs/duplicates](http://pusherapp.com/docs/duplicates)):
+([https://pusher.com/docs/duplicates](https://pusher.com/docs/channels/server_api/excluding-event-recipients)):
 
 ```php
-$pusher->trigger('my-channel','event','data','socket_id');
+$pusher->trigger('my-channel', 'event', 'data', array('socket_id' => $socket_id));
+```
+
+```php
+$batch = array();
+$batch[] = array('channel' => 'my-channel', 'name' => 'my_event', 'data' => array('hello' => 'world'), array('socket_id' => $socket_id));
+$batch[] = array('channel' => 'my-channel', 'name' => 'my_event', 'data' => array('myname' => 'bob'), array('socket_id' => $socket_id);
+$pusher->triggerBatch($batch);
+```
+
+### Fetch channel info on publish
+
+It is possible to request for attributes about the channels that were
+published to with the `info` param
+([https://pusher.com/docs/duplicates](https://pusher.com/docs/channels/library_auth_reference/rest-api#request)):
+
+```php
+$result = $pusher->trigger('my-channel', 'my_event', 'hello world', array('info' => 'subscription_count'));
+$subscription_count = $result->channels['my-channel']->subscription_count;
+```
+
+```php
+$batch = array();
+$batch[] = array('channel' => 'my-channel', 'name' => 'my_event', 'data' => array('hello' => 'world'), 'info' => array('info' => 'subscription_count'));
+$batch[] = array('channel' => 'presence-my-channel', 'name' => 'my_event', 'data' => array('myname' => 'bob'), 'info' => array('info' => 'user_count,subscription_count'));
+$channels = $pusher->triggerBatch($batch);
+$subscription_count = count($result->channels['my-channel']->subscription_count);
+$user_count = count($result->channels['presence-my-channel']->user_count);
 ```
 
 ### JSON format
@@ -196,7 +223,7 @@ If your data is already encoded in JSON format, you can avoid a second encoding
 step by setting the sixth argument true, like so:
 
 ```php
-$pusher->trigger('my-channel', 'event', 'data', null, true)
+$pusher->trigger('my-channel', 'event', 'data', array(), true)
 ```
 
 ## Authenticating Private channels

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -593,13 +593,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
             throw new ApiErrorException($response['body'], $response['status']);
         }
 
-        $result = json_decode($response['body']);
-
-        if ($result->channels) {
-            $result->channels = get_object_vars($result->channels);
-        }
-
-        return $result;
+        return json_decode($response['body']);
     }
 
     /**

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -462,7 +462,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
      * @param array|string $channels        A channel name or an array of channel names to publish the event on.
      * @param string       $event
      * @param mixed        $data            Event data
-     * @param array        $params       [optional]
+     * @param array        $params          [optional]
      * @param bool         $already_encoded [optional]
      *
      * @throws PusherException   Throws PusherException if $channels is an array of size 101 or above or $socket_id is invalid

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -462,7 +462,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
      * @param array|string $channels        A channel name or an array of channel names to publish the event on.
      * @param string       $event
      * @param mixed        $data            Event data
-     * @param string|null  $socket_id       [optional]
+     * @param array        $params       [optional]
      * @param bool         $already_encoded [optional]
      *
      * @throws PusherException   Throws PusherException if $channels is an array of size 101 or above or $socket_id is invalid
@@ -470,14 +470,16 @@ class Pusher implements LoggerAwareInterface, PusherInterface
      *
      * @return object
      */
-    public function trigger($channels, $event, $data, $socket_id = null, $already_encoded = false)
+    public function trigger($channels, $event, $data, $params = array(), $already_encoded = false)
     {
         if (is_string($channels) === true) {
             $channels = array($channels);
         }
 
         $this->validate_channels($channels);
-        $this->validate_socket_id($socket_id);
+        if (isset($params['socket_id'])) {
+            $this->validate_socket_id($params['socket_id']);
+        }
 
         $has_encrypted_channel = false;
         foreach ($channels as $chan) {
@@ -513,11 +515,9 @@ class Pusher implements LoggerAwareInterface, PusherInterface
         $post_params['data'] = $data_encoded;
         $post_params['channels'] = array_values($channels);
 
-        if ($socket_id !== null) {
-            $post_params['socket_id'] = $socket_id;
-        }
+        $all_params = array_merge($post_params, $params);
 
-        $post_value = json_encode($post_params);
+        $post_value = json_encode($all_params);
 
         $query_params['body_md5'] = md5($post_value);
 
@@ -533,7 +533,13 @@ class Pusher implements LoggerAwareInterface, PusherInterface
             throw new ApiErrorException($response['body'], $response['status']);
         }
 
-        return json_decode($response['body']);
+        $result = json_decode($response['body']);
+
+        if ($result->channels) {
+            $result->channels = get_object_vars($result->channels);
+        }
+
+        return $result;
     }
 
     /**
@@ -587,7 +593,13 @@ class Pusher implements LoggerAwareInterface, PusherInterface
             throw new ApiErrorException($response['body'], $response['status']);
         }
 
-        return json_decode($response['body']);
+        $result = json_decode($response['body']);
+
+        if ($result->channels) {
+            $result->channels = get_object_vars($result->channels);
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/acceptance/triggerBatchTest.php
+++ b/tests/acceptance/triggerBatchTest.php
@@ -91,10 +91,10 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
         $expectedPresenceMyChannel->user_count = 0;
         $expectedPresenceMyChannel->subscription_count = 0;
         $expectedResult = new stdClass();
-        $expectedResult->channels = array(
-            'my-channel' => $expectedMyChannel,
-            'my-channel-2' => $expectedMyChannel2,
-            'presence-my-channel' => $expectedPresenceMyChannel
+        $expectedResult->batch = array(
+            $expectedMyChannel,
+            $expectedMyChannel2,
+            $expectedPresenceMyChannel
         );
 
         $batch = array();

--- a/tests/acceptance/triggerBatchTest.php
+++ b/tests/acceptance/triggerBatchTest.php
@@ -73,6 +73,38 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(new stdClass(), $result);
     }
 
+    public function testTriggerBatchWithInfo()
+    {
+        $this->markTestIncomplete('Pending support in Channels server');
+
+        $options = array(
+            'useTLS' => true,
+            'host'   => PUSHERAPP_HOST,
+        );
+        $pc = new Pusher\Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, $options);
+        $pc->setLogger(new TestLogger());
+
+        $expectedMyChannel = new stdClass();
+        $expectedMyChannel->subscription_count = 1;
+        $expectedMyChannel2 = new stdClass();
+        $expectedPresenceMyChannel = new stdClass();
+        $expectedPresenceMyChannel->user_count = 0;
+        $expectedPresenceMyChannel->subscription_count = 0;
+        $expectedResult = new stdClass();
+        $expectedResult->channels = array(
+            'my-channel' => $expectedMyChannel,
+            'my-channel-2' => $expectedMyChannel2,
+            'presence-my-channel' => $expectedPresenceMyChannel
+        );
+
+        $batch = array();
+        $batch[] = array('channel' => 'my-channel', 'name' => 'my_event', 'data' => 'test-string', array('info' => 'subscription_count'));
+        $batch[] = array('channel' => 'my-channel-2', 'name' => 'my_event', 'data' => 'test-string');
+        $batch[] = array('channel' => 'presence-my-channel', 'name' => 'my_event', 'data' => 'test-string', array('info' => 'user_count,subscription_count'));
+        $result = $pc->triggerBatch($batch);
+        $this->assertEquals($expectedResult, $result);
+    }
+
     public function testTriggerBatchWithMultipleNonEncryptedEventsWithStringPayloads()
     {
         $options = array(
@@ -198,7 +230,7 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
         $data = str_pad('', 11 * 1024, 'a');
         $batch = array();
         $batch[] = array('channel' => 'test_channel', 'name' => 'my_event', 'data' => $data);
-        $this->pusher->triggerBatch($batch, true, true);
+        $this->pusher->triggerBatch($batch, true);
     }
 
     public function testSendingOver10messagesReturns400()
@@ -211,6 +243,6 @@ class PusherBatchPushTest extends PHPUnit\Framework\TestCase
         foreach (range(1, 11) as $i) {
             $batch[] = array('channel' => 'test_channel', 'name' => 'my_event', 'data' => array('index' => $i));
         }
-        $this->pusher->triggerBatch($batch, true, false);
+        $this->pusher->triggerBatch($batch, false);
     }
 }

--- a/tests/acceptance/triggerTest.php
+++ b/tests/acceptance/triggerTest.php
@@ -31,6 +31,31 @@ class PusherPushTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(new stdClass(), $result);
     }
 
+    public function testPushWithSocketId()
+    {
+        $result = $this->pusher->trigger('test_channel', 'my_event', array('test' => 1), array('socket_id' => '123.456'));
+        $this->assertEquals(new stdClass(), $result);
+    }
+
+    public function testPushWithInfo()
+    {
+        $this->markTestIncomplete('Pending support in Channels server');
+        $expectedMyChannel = new stdClass();
+        $expectedMyChannel->user_count = 0;
+        $expectedMyChannel->subscription_count = 1;
+        $expectedPresenceMyChannel = new stdClass();
+        $expectedPresenceMyChannel->user_count = 0;
+        $expectedPresenceMyChannel->subscription_count = 0;
+        $expectedResult = new stdClass();
+        $expectedResult->channels = array(
+            "my-channel" => $expectedMyChannel,
+            "presence-my-channel" => $expectedPresenceMyChannel,
+        );
+
+        $result = $this->pusher->trigger(['my-channel', 'presence-my-channel'], 'my_event', array('test' => 1), array('info' => 'user_count,subscription_count'));
+        $this->assertEquals($expectedResult, $result);
+    }
+
     public function testTLSPush()
     {
         $options = array(
@@ -51,7 +76,7 @@ class PusherPushTest extends PHPUnit\Framework\TestCase
 
         $data = str_pad('', 11 * 1024, 'a');
         echo  'sending data of size: '.mb_strlen($data, '8bit');
-        $this->pusher->trigger('test_channel', 'my_event', $data, null, true);
+        $this->pusher->trigger('test_channel', 'my_event', $data, array(), true);
     }
 
     public function testTriggeringEventOnOver100ChannelsThrowsException()

--- a/tests/unit/triggerUnitTest.php
+++ b/tests/unit/triggerUnitTest.php
@@ -48,41 +48,41 @@ class PusherTriggerUnitTest extends PHPUnit\Framework\TestCase
     {
         $this->expectException(\Pusher\PusherException::class);
 
-        $this->pusher->trigger('test_channel:', $this->eventName, $this->data, '1.1:');
+        $this->pusher->trigger('test_channel:', $this->eventName, $this->data, array('socket_id' => '1.1:'));
     }
 
     public function testLeadingColonSocketIDThrowsException()
     {
         $this->expectException(\Pusher\PusherException::class);
 
-        $this->pusher->trigger('test_channel:', $this->eventName, $this->data, ':1.1');
+        $this->pusher->trigger('test_channel:', $this->eventName, $this->data, array('socket_id' => ':1.1'));
     }
 
     public function testLeadingColonNLSocketIDThrowsException()
     {
         $this->expectException(\Pusher\PusherException::class);
 
-        $this->pusher->trigger('test_channel:', $this->eventName, $this->data, ':\n1.1');
+        $this->pusher->trigger('test_channel:', $this->eventName, $this->data, array('socket_id' => ':\n1.1'));
     }
 
     public function testTrailingColonNLSocketIDThrowsException()
     {
         $this->expectException(\Pusher\PusherException::class);
 
-        $this->pusher->trigger('test_channel:', $this->eventName, $this->data, '1.1\n:');
+        $this->pusher->trigger('test_channel:', $this->eventName, $this->data, array('socket_id' => '1.1\n:'));
     }
 
     public function testFalseSocketIDThrowsException()
     {
         $this->expectException(\Pusher\PusherException::class);
 
-        $this->pusher->trigger('test_channel', $this->eventName, $this->data, false);
+        $this->pusher->trigger('test_channel', $this->eventName, $this->data, array('socket_id' => false));
     }
 
     public function testEmptyStrSocketIDThrowsException()
     {
         $this->expectException(\Pusher\PusherException::class);
 
-        $this->pusher->trigger('test_channel', $this->eventName, $this->data, '');
+        $this->pusher->trigger('test_channel', $this->eventName, $this->data, array('socket_id' => ''));
     }
 }


### PR DESCRIPTION
Adds support for a new experimental feature of the Channels API:
Specifically the ability to specify an `info` parameter in a
trigger body, or with an event in a batch trigger body. The server
will respond with attributes in the same format as the `/channels`
endpoint.

The `info` param is specified in a "params" associative array,
which is passed in as the fourth parameter to the `trigger` method.
The `socket_id` parameter is specified in the same way.

Note: this introduces a breaking change for users that were
passing in more than 3 parameters to `trigger`.

It is not a breaking change for `triggerBatch`.

Resolves https://github.com/pusher/pusher-http-php/issues/267.

- [ ] Enable acceptance tests once server support is released.