### PR TITLE
Fix "Undefined property: stdClass::$channels"

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -535,7 +535,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
 
         $result = json_decode($response['body']);
 
-        if ($result->channels) {
+        if (property_exists($result, 'channels') === true) {
             $result->channels = get_object_vars($result->channels);
         }
 

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -535,7 +535,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
 
         $result = json_decode($response['body']);
 
-        if (property_exists($result, 'channels') === true) {
+        if (property_exists($result, 'channels')) {
             $result->channels = get_object_vars($result->channels);
         }
 


### PR DESCRIPTION
If no `info` key is present in the `$params` array Pusher will not return the channels property in the request. There is a if statement in place, but it doesn't check if the property actually exists.

So by just using the package and using the trigger method will provide you with a exception.