### PR TITLE
Ensure version is bumped in source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,12 @@ jobs:
         run: |
           export MAJOR=$(echo "${{ env.VERSION }}" | cut -d'.' -f1)
           sed -i "s|\"pusher/pusher-php-server\": \"^[0-9]*\.0\"|\"pusher/pusher-php-server\": \"^${MAJOR}.0\"|" README.md
+      - name: Prepare Pusher.php
+        run: |
+          sed -i "s|public static \$VERSION = '[^']*'|public static \$VERSION = '${{ env.VERSION }}'|" src/Pusher.php
       - name: Commit changes
         run: |
-          git add CHANGELOG.md README.md
+          git add CHANGELOG.md README.md src/Pusher.php
           git commit -m "Bump to version ${{ env.VERSION }}"
       - name: Push
         run: git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.3
+
+* [CHANGED] Ensure version in Pusher.php is bumped on release.
+
 ## 5.0.2
 
 * [CHANGED] Add release automation actions.

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -14,7 +14,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     /**
      * @var string Version
      */
-    public static $VERSION = '5.0.1';
+    public static $VERSION = '5.0.3';
 
     /**
      * @var null|PusherCrypto


### PR DESCRIPTION
## Description

The latest patch release, 5.0.2, missed the version variable in Pusher.php.

## CHANGELOG

* [CHANGED] Ensure version in Pusher.php is bumped on release.
