### PR TITLE
Fix infinite recursion in presence_auth()

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -837,7 +837,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
      */
     public function presence_auth(string $channel, string $socket_id, string $user_id, $user_info = null): string
     {
-        return $this->presence_auth($channel, $socket_id, $user_id, $user_info);
+        return $this->presenceAuth($channel, $socket_id, $user_id, $user_info);
     }
 
     /**


### PR DESCRIPTION
## Description

Calling the deprecated [`presence_auth()`](https://github.com/pusher/pusher-http-php/blob/master/src/Pusher.php#L838) function in `Pusher.php` always leads to infinite recursion since it calls itself with the same arguments. I believe that this was meant to call `presenceAuth()` instead.

## CHANGELOG

* [FIXED] Infinite recursion caused by `presence_auth()`
