### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.0.1
+
+* [FIXED] Infinite recursion in `presence_auth`.
+
 ## 7.0.0
 
 * [DEPRECATED] `get_channel_info`, `get_channels`, `socket_auth`, `presence_auth` in favour of camelCased versions

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -18,7 +18,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     /**
      * @var string Version
      */
-    public static $VERSION = '7.0.0';
+    public static $VERSION = '7.0.1';
 
     /**
      * @var null|PusherCrypto


### PR DESCRIPTION
## Description

Calling the deprecated [`presence_auth()`](https://github.com/pusher/pusher-http-php/blob/master/src/Pusher.php#L838) function in `Pusher.php` always leads to infinite recursion since it calls itself with the same arguments.

## CHANGELOG

* [FIXED] Infinite recursion caused by `presence_auth()`
