### PR TITLE
Add support for the ConnectException from Guzzle

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -3,6 +3,7 @@
 namespace Pusher;
 
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -432,10 +433,14 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     {
         $request = $this->make_request($channels, $event, $data, $params, $already_encoded);
 
-        $response = $this->client->send($request, [
-            'http_errors' => false,
-            'base_uri' => $this->channels_url_prefix()
-        ]);
+        try {
+            $response = $this->client->send($request, [
+                'http_errors' => false,
+                'base_uri' => $this->channels_url_prefix()
+            ]);
+        } catch (ConnectException $e) {
+            throw new ApiErrorException($e->getMessage());
+        }
 
         $status = $response->getStatusCode();
 
@@ -492,6 +497,8 @@ class Pusher implements LoggerAwareInterface, PusherInterface
             }
 
             return $result;
+        }, function (ConnectException $e) {
+            throw new ApiErrorException($e->getMessage());
         });
 
         return $promise;

--- a/tests/acceptance/TriggerAsyncTest.php
+++ b/tests/acceptance/TriggerAsyncTest.php
@@ -129,4 +129,14 @@ class TriggerAsyncTest extends TestCase
         $channels = ['my-chan-ceppaio', 'private-encrypted-ceppaio'];
         $this->pusher->triggerAsync($channels, 'my_event', $data)->wait();
     }
+
+    public function testTriggeringApiExceptionIfConnectionErrorOcurred(): void
+    {
+        $this->expectException(\Pusher\ApiErrorException::class);
+
+        $options = ['host' => 'invalidhost'];
+        $this->pusher = new Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, $options);
+
+        $this->pusher->triggerAsync('test_channel', 'my_event', 'event_data')->wait();
+    }
 }

--- a/tests/acceptance/TriggerTest.php
+++ b/tests/acceptance/TriggerTest.php
@@ -131,4 +131,14 @@ class TriggerTest extends TestCase
         $channels = ['my-chan-ceppaio', 'private-encrypted-ceppaio'];
         $this->pusher->trigger($channels, 'my_event', $data);
     }
+
+    public function testTriggeringApiExceptionIfConnectionErrorOcurred(): void
+    {
+        $this->expectException(ApiErrorException::class);
+
+        $options = ['host' => 'invalidhost'];
+        $this->pusher = new Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, $options);
+
+        $this->pusher->trigger('test_channel', 'my_event', 'event_data');
+    }
 }


### PR DESCRIPTION
## Description

Found out if there is a connection issue, the SDK is not handling that exception, my pull request add the support and returns an `ApiErrorException`

## CHANGELOG

* Add support for ConnectException from Guzzle
