### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.0.2
+
+* [CHANGED] Add psr/log v2.0 and v3.0 compatibility
+
 ## 7.0.1
 
 * [FIXED] Infinite recursion in `presence_auth`.

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "paragonie/sodium_compat": "^1.6"
     },
     "require-dev": {

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -19,7 +19,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     /**
      * @var string Version
      */
-    public static $VERSION = '7.0.1';
+    public static $VERSION = '7.0.2';
 
     /**
      * @var null|PusherCrypto


### PR DESCRIPTION
## Description

This allows better compatibility with other libraries which use more recent lock versions of ```psr/log```.

Tested with locked version ```^1.0``` of ```psr/log```.
Tested with locked version ```^2.0``` of ```psr/log```.
Tested with locked version ```^3.0``` of ```psr/log```.

Fixes #316 

## CHANGELOG

* [CHANGED] Add psr/log v2.0 and v3.0 compatibility
