### PR TITLE
Fix Backward Compatibility for servers running Pusher < 5.0.0

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -455,7 +455,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
             throw new PusherException('Data encoding error.');
         }
 
-        if (property_exists($result, 'channels')) {
+        if (property_exists($result, 'channels') && is_object($result->channels)) {
             $result->channels = get_object_vars($result->channels);
         }
 
@@ -492,7 +492,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
 
             $result = json_decode($response->getBody(), null, 512, JSON_THROW_ON_ERROR);
 
-            if (property_exists($result, 'channels')) {
+            if (property_exists($result, 'channels') && is_object($result->channels)) {
                 $result->channels = get_object_vars($result->channels);
             }
 
@@ -601,7 +601,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
             throw new PusherException('Data encoding error.');
         }
 
-        if (property_exists($result, 'channels')) {
+        if (property_exists($result, 'channels') && is_object($result->channels)) {
             $result->channels = get_object_vars($result->channels);
         }
 
@@ -634,7 +634,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
 
             $result = json_decode($response->getBody(), false, 512, JSON_THROW_ON_ERROR);
 
-            if (property_exists($result, 'channels')) {
+            if (property_exists($result, 'channels') && is_object($result->channels)) {
                 $result->channels = get_object_vars($result->channels);
             }
 


### PR DESCRIPTION
## Description

Closes #322, calling `get_object_vars($result->channels)` function in `Pusher.php` on response of old versions of pusher servers `<v5.0.0` lead to  `TypeError` Exception, as an `array` is passed instead of `object`.

## CHANGELOG

* [FIXED] `get_object_vars()` error on `/src/Pusher.php`
