### PR TITLE
Added the possibility of passing query params to the getPresenceUsers 

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -702,22 +702,23 @@ class Pusher implements LoggerAwareInterface, PusherInterface
      * Fetch user ids currently subscribed to a presence channel.
      *
      * @param string $channel The name of the channel
+     * @param array  $params      API params (see http://pusher.com/docs/rest_api)
      *
      * @throws ApiErrorException Throws ApiErrorException if the Channels HTTP API responds with an error
      * @throws GuzzleException
      *
      */
-    public function getPresenceUsers(string $channel): object
+    public function getPresenceUsers(string $channel, array $params = []): object
     {
-        return $this->get('/channels/' . $channel . '/users');
+        return $this->get('/channels/' . $channel . '/users', $params);
     }
 
     /**
      * @deprecated in favour of getPresenceUsers
      */
-    public function get_users_info(string $channel): object
+    public function get_users_info(string $channel, array $params = []): object
     {
-        return $this->getPresenceUsers($channel);
+        return $this->getPresenceUsers($channel, $params);
     }
 
     /**


### PR DESCRIPTION
## Description

Added the possibility of passing query params to the getPresenceUsers and the (deprecated) get_users_info in order to support the feature implemented by Soketi, and, hopefully, Pusher, where we can add a with_user_info=1 to this endpoint.

https://github.com/soketi/soketi/pull/450

The addition is retro compatible and does not impact current implementations.

## CHANGELOG

* [CHANGED] Added an optional param to the getPresenceUsers and get_users_info, the first parameter is the channel name (as of now) and the second optional parameter is an associative array with query string parameters.
