### PR TITLE
Refactor trigger(Batch) and introduce sendToUser

### DIFF
--- a/tests/acceptance/SendToUserTest.php
+++ b/tests/acceptance/SendToUserTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace acceptance;
+
+use GuzzleHttp;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Exception\RequestException;
+use PHPUnit\Framework\TestCase;
+use Pusher\ApiErrorException;
+use Pusher\Pusher;
+use Pusher\PusherException;
+use stdClass;
+
+class SendToUserTest extends TestCase
+{
+
+    /**
+     * @var Pusher
+     */
+    private $pusher;
+
+    protected function setUp(): void
+    {
+        if (PUSHERAPP_AUTHKEY === '' || PUSHERAPP_SECRET === '' || PUSHERAPP_APPID === '') {
+            self::markTestSkipped('Please set the
+            PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET and
+            PUSHERAPP_APPID keys.');
+        } else {
+            $this->pusher = new Pusher(PUSHERAPP_AUTHKEY, PUSHERAPP_SECRET, PUSHERAPP_APPID, ['cluster' => PUSHERAPP_CLUSTER]);
+        }
+    }
+
+    public function testSendToUser(): void
+    {
+        $result = $this->pusher->sendToUser('123', 'my_event', 'Test string');
+        self::assertEquals(new stdClass(), $result);
+    }
+
+    public function testSendToUserAsync(): void
+    {
+        $result = $this->pusher->sendToUserAsync('123', 'my_event', 'Test string')->wait();
+        self::assertEquals(new stdClass(), $result);
+    }
+
+    public function testBadUserId(): void
+    {
+        $this->expectException(PusherException::class);
+        $this->pusher->terminateUserConnections("");
+    }
+
+    public function testBadUserIdAsync(): void
+    {
+        $this->expectException(PusherException::class);
+        $this->pusher->terminateUserConnectionsAsync("");
+    }
+}

--- a/tests/unit/SendToUserTest.php
+++ b/tests/unit/SendToUserTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace unit;
+
+use GuzzleHttp;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Exception\RequestException;
+use PHPUnit\Framework\TestCase;
+use Pusher\ApiErrorException;
+use Pusher\Pusher;
+use Pusher\PusherException;
+use stdClass;
+
+class SendToUserTest extends TestCase
+{
+    private $request_history = [];
+
+    private function mockPusher(array $responses): Pusher
+    {
+        $mockHandler = new GuzzleHttp\Handler\MockHandler($responses);
+        $history = GuzzleHttp\Middleware::history($this->request_history);
+        $handlerStack = GuzzleHttp\HandlerStack::create($mockHandler);
+        $handlerStack->push($history);
+        $httpClient = new GuzzleHttp\Client(['handler' => $handlerStack]);
+        return new Pusher("auth-key", "secret", "appid", ['cluster' => 'test1'], $httpClient);
+    }
+
+    public function testSendUser(): void
+    {
+        $pusher = $this->mockPusher([new Response(200, [], "{}")]);
+        $result = $pusher->sendToUser("123", "my-event", "event-data");
+        self::assertEquals(new stdClass(), $result);
+        self::assertEquals(1, count($this->request_history));
+        $request = $this->request_history[0]['request'];
+        self::assertEquals('api-test1.pusher.com', $request->GetUri()->GetHost());
+        self::assertEquals('POST', $request->GetMethod());
+        self::assertEquals('/apps/appid/events', $request->GetUri()->GetPath());
+        self::assertEquals(
+            '{"name":"my-event","data":"\"event-data\"","channel":"#server-to-user-123"}',
+            (string) $request->GetBody()
+        );
+    }
+
+    public function testBadUserId(): void
+    {
+        $pusher = $this->mockPusher([]);
+        $this->expectException(PusherException::class);
+        $pusher->sendToUser("", "my-event", "event data");
+    }
+
+    public function testBadUserIdAsync(): void
+    {
+        $pusher = $this->mockPusher([]);
+        $this->expectException(PusherException::class);
+        $pusher->sendToUserAsync("", "my-event", "event data");
+    }
+}


### PR DESCRIPTION
## Description

Refactor trigger functions to reduce code duplication and introduce sendToUser functions

## CHANGELOG

* [ADDED] sendToUser and sendToUserAsync functions
* [DEPRECATED] deprecate internal functions make_request and make_batch_request that were exposed as public