### PR TITLE
Add authenticateUser function and rename socketAuth to authorizeChannel

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -956,7 +956,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
      */
     public function socket_auth(string $channel, string $socket_id, string $custom_data = null): string
     {
-        return $this->socketAuth($channel, $socket_id, $custom_data);
+        return $this->autorizeChannel($channel, $socket_id, $custom_data);
     }
 
     /**
@@ -968,11 +968,11 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     }
 
     /**
-     * @deprecated in favour of presenceAuth
+     * @deprecated in favour of authorizePresenceChannel
      */
     public function presence_auth(string $channel, string $socket_id, string $user_id, $user_info = null): string
     {
-        return $this->presenceAuth($channel, $socket_id, $user_id, $user_info);
+        return $this->authorizePresenceChannel($channel, $socket_id, $user_id, $user_info);
     }
 
     /**

--- a/tests/unit/AuthenticateUserTest.php
+++ b/tests/unit/AuthenticateUserTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace unit;
+
+use PHPUnit\Framework\TestCase;
+use Pusher\Pusher;
+use Pusher\PusherException;
+
+class AuthenticateUserTest extends TestCase
+{
+    /**
+     * @var Pusher
+     */
+    private $pusher;
+
+    protected function setUp(): void
+    {
+        $this->pusher = new Pusher('thisisaauthkey', 'thisisasecret', 1, []);
+    }
+
+    public function testObjectConstruct(): void
+    {
+        $this->assertNotNull($this->pusher, 'Created new \Pusher\Pusher object');
+    }
+
+    public function testAuthenticateUser(): void
+    {
+        $auth_string = $this->pusher->authenticateUser('12345.6789', ['id' => '123']);
+        self::assertEquals(
+            '{"auth":"fc713f433deb729d0d96f9e26ef054285cbc3e833ebe840b93722a2fa16a6a18","user_data":"{\"id\":\"123\"}"}',
+            $auth_string,
+            'Auth string valid'
+        );
+    }
+
+    public function testAuthenticateUserUserData(): void
+    {
+        $auth_string = $this->pusher->authenticateUser('12345.6789', ['id' => '123', 'name' => 'John Smith']);
+        self::assertEquals(
+            '{"auth":"0dddb208b53c7649f3fbbb86254a6e1986bc6f8b566423ea690c9ca773497373","user_data":"{\"id\":\"123\",\"name\":\"John Smith\"}"}',
+            $auth_string,
+            'Auth string valid'
+        );
+    }
+
+    public function testInvalidSocketId(): void
+    {
+        $this->expectException(PusherException::class);
+
+        $this->pusher->authorizeChannel('invalid-socket-id', '123');
+    }
+
+    public function testInvalidUserId(): void
+    {
+        $this->expectException(PusherException::class);
+
+        $this->pusher->authenticateUser('12345.6789', ['id' => '']);
+    }
+
+    public function testInvalidInvalidUserData(): void
+    {
+        $this->expectException(PusherException::class);
+
+        $this->pusher->authenticateUser('12345.6789', ['name' => 'John Smith']);
+    }
+}

--- a/tests/unit/AuthorizeChannelTest.php
+++ b/tests/unit/AuthorizeChannelTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Pusher\Pusher;
 use Pusher\PusherException;
 
-class SocketAuthTest extends TestCase
+class AuthorizeChannelTest extends TestCase
 {
     /**
      * @var Pusher
@@ -23,23 +23,33 @@ class SocketAuthTest extends TestCase
         $this->assertNotNull($this->pusher, 'Created new \Pusher\Pusher object');
     }
 
-    public function testSocketAuthKey(): void
+    public function testAuthorizeChannel(): void
     {
-        $socket_auth = $this->pusher->socket_auth('testing_pusher-php', '1.1');
+        $auth_string = $this->pusher->authorizeChannel('testing_pusher-php', '1.1');
         self::assertEquals(
             '{"auth":"thisisaauthkey:751ccc12aeaa79d46f7c199bced5fa47527d3480b51fe61a0bd10438241bd52d"}',
-            $socket_auth,
-            'Socket auth key valid'
+            $auth_string,
+            'Auth string key valid'
         );
     }
 
-    public function testComplexSocketAuthKey(): void
+    public function testComplexAuthorizeChannel(): void
     {
-        $socket_auth = $this->pusher->socket_auth('-azAZ9_=@,.;', '45055.28877557');
+        $auth_string = $this->pusher->authorizeChannel('-azAZ9_=@,.;', '45055.28877557');
         self::assertEquals(
             '{"auth":"thisisaauthkey:d1c20ad7684c172271f92c108e11b45aef07499b005796ae1ec5beb924f361c4"}',
-            $socket_auth,
-            'Socket auth key valid'
+            $auth_string,
+            'Auth string key valid'
+        );
+    }
+
+    public function testAuthorizeChannelWithChannelData(): void
+    {
+        $auth_string = $this->pusher->authorizeChannel('-azAZ9_=@,.;', '45055.28877557', '{"user_id": "123"}');
+        self::assertEquals(
+            '{"auth":"thisisaauthkey:3b3f1dcc4d7d2f95dd10ed05562397b3287b102d4cccfacbf30eed2f1ffa3d69","channel_data":"{\"user_id\": \"123\"}"}',
+            $auth_string,
+            'Auth string key valid'
         );
     }
 
@@ -47,55 +57,55 @@ class SocketAuthTest extends TestCase
     {
         $this->expectException(PusherException::class);
 
-        $this->pusher->socket_auth('testing_pusher-php', '1.1:');
+        $this->pusher->authorizeChannel('testing_pusher-php', '1.1:');
     }
 
     public function testLeadingColonSocketIDThrowsException(): void
     {
         $this->expectException(PusherException::class);
 
-        $this->pusher->socket_auth('testing_pusher-php', ':1.1');
+        $this->pusher->authorizeChannel('testing_pusher-php', ':1.1');
     }
 
     public function testLeadingColonNLSocketIDThrowsException(): void
     {
         $this->expectException(PusherException::class);
 
-        $this->pusher->socket_auth('testing_pusher-php', ':\n1.1');
+        $this->pusher->authorizeChannel('testing_pusher-php', ':\n1.1');
     }
 
     public function testTrailingColonNLSocketIDThrowsException(): void
     {
         $this->expectException(PusherException::class);
 
-        $this->pusher->socket_auth('testing_pusher-php', '1.1\n:');
+        $this->pusher->authorizeChannel('testing_pusher-php', '1.1\n:');
     }
 
     public function testTrailingColonChannelThrowsException(): void
     {
         $this->expectException(PusherException::class);
 
-        $this->pusher->socket_auth('test_channel:', '1.1');
+        $this->pusher->authorizeChannel('test_channel:', '1.1');
     }
 
     public function testLeadingColonChannelThrowsException(): void
     {
         $this->expectException(PusherException::class);
 
-        $this->pusher->socket_auth(':test_channel', '1.1');
+        $this->pusher->authorizeChannel(':test_channel', '1.1');
     }
 
     public function testLeadingColonNLChannelThrowsException(): void
     {
         $this->expectException(PusherException::class);
 
-        $this->pusher->socket_auth(':\ntest_channel', '1.1');
+        $this->pusher->authorizeChannel(':\ntest_channel', '1.1');
     }
 
     public function testTrailingColonNLChannelThrowsException(): void
     {
         $this->expectException(PusherException::class);
 
-        $this->pusher->socket_auth('test_channel\n:', '1.1');
+        $this->pusher->authorizeChannel('test_channel\n:', '1.1');
     }
 }


### PR DESCRIPTION
## Description

Add `authenticateUser`, `authorizeChannel` and `authorizePresenceChannel` (convenience function). Deprecate `socketAuth` and related functions

## CHANGELOG

* [ADDED] authenticateUser, authorizeChannel and authorizePresenceChannel
* [DEPRECATED] socketAuth and presenceAuth
