### PR TITLE
Multiple channels e2e

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -1070,9 +1070,8 @@ class Pusher implements LoggerAwareInterface, PusherInterface
         }
 
         if ($has_encrypted_channel) {
-            if (count($channels) > 1) {
-                // For rationale, see limitations of end-to-end encryption in the README
-                throw new PusherException('You cannot trigger to multiple channels when using encrypted channels');
+            if (PusherCrypto::has_mixed_channels($channels)) {
+                throw new PusherException('You cannot trigger to encrypted and non-encrypted channels at the same time');
             } else {
                 try {
                     $data_encoded = $this->crypto->encrypt_payload(

--- a/src/PusherCrypto.php
+++ b/src/PusherCrypto.php
@@ -22,26 +22,33 @@ class PusherCrypto
     }
 
     /**
-     * Checks if channels are mix of encrypted and non-encrypted types.
+     * Checks if channels are a mix of encrypted and non-encrypted types.
      *
      * @param  array  $channels
      * @return bool true when mixed channel types are discovered
      */
     public static function has_mixed_channels(array $channels): bool
     {
-        $encrypted = 0;
+        $unencrypted_seen = false;
+        $encrypted_seen = false;
 
         foreach ($channels as $channel) {
             if(self::is_encrypted_channel($channel)) {
-                $encrypted++;
+                if ($unencrypted_seen) {
+                    return true;
+                } else {
+                    $encrypted_seen = true;
+                }
+            } else {
+                if ($encrypted_seen) {
+                    return true;
+                } else {
+                    $unencrypted_seen = true;
+                }
             }
         }
-
-        if($encrypted === 0 || $encrypted === count($channels)) {
-            return false;
-        }
-
-        return true;
+        
+        return false;
     }
 
     /**

--- a/src/PusherCrypto.php
+++ b/src/PusherCrypto.php
@@ -22,6 +22,29 @@ class PusherCrypto
     }
 
     /**
+     * Checks if channels are mix of encrypted and non-encrypted types.
+     *
+     * @param  array  $channels
+     * @return bool true when mixed channel types are discovered
+     */
+    public static function has_mixed_channels(array $channels): bool
+    {
+        $encrypted = 0;
+
+        foreach ($channels as $channel) {
+            if(self::is_encrypted_channel($channel)) {
+                $encrypted++;
+            }
+        }
+
+        if($encrypted === 0 || $encrypted === count($channels)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * @param $encryption_master_key_base64
      * @return string
      * @throws PusherException

--- a/tests/unit/CryptoTest.php
+++ b/tests/unit/CryptoTest.php
@@ -101,6 +101,15 @@ class CryptoTest extends TestCase
         self::assertEquals(false, PusherCrypto::is_encrypted_channel('test-private-encrypted'));
     }
 
+    public function testHasMixedChannels(): void
+    {
+        self::assertEquals(false, PusherCrypto::has_mixed_channels(['private-encrypted-test']));
+        self::assertEquals(false, PusherCrypto::has_mixed_channels(['another']));
+        self::assertEquals(true, PusherCrypto::has_mixed_channels(['private-encrypted-test', 'another']));
+        self::assertEquals(false, PusherCrypto::has_mixed_channels(['private-encrypted-test', 'private-encrypted-another']));
+        self::assertEquals(false, PusherCrypto::has_mixed_channels(['test', 'another']));
+    }
+
     public function testEncryptDecryptEventValid(): void
     {
         $channel = 'private-encrypted-bla';


### PR DESCRIPTION
## Description

This PR allows the triggering of a single encrypted events on multiple channels. It addresses issue #334.

Instead of throwing an exception if more than 1 encrypted channel is specified, it throws if the channels are mixed encrypted / unencrypted. This still means that only 1 API request is made as mentioned in the readme rationale.

## CHANGELOG

* [ADDED] `has_mixed_channels` method to allow triggering a single event on multiple channels 
