### PR TITLE
fix(publish): add composer.phar to .gitattributes to avoid class duplicates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/composer.phar export-ignore
 /phpunit.xml.dist export-ignore
 /README.md export-ignore
 /pull_request_template.md export-ignore


### PR DESCRIPTION
Because of `composer.phar` file that ends up in our `./vendor/pusher/....` class, we get to have many duplicate classes in IDEs. Published lib doesn't need this bulky file, so let's get rid of it.