### PR TITLE
Check check for null values for host and cluster

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -97,9 +97,9 @@ class Pusher implements LoggerAwareInterface, PusherInterface
 
         // handle the case when 'host' and 'cluster' are specified in the options.
         if (!array_key_exists('host', $this->settings)) {
-            if (array_key_exists('host', $options)) {
+            if (array_key_exists('host', $options) && $options['host']) {
                 $this->settings['host'] = $options['host'];
-            } elseif (array_key_exists('cluster', $options)) {
+            } elseif (array_key_exists('cluster', $options) && $option['cluster']) {
                 $this->settings['host'] = 'api-' . $options['cluster'] . '.pusher.com';
             } else {
                 $this->settings['host'] = 'api-mt1.pusher.com';


### PR DESCRIPTION
## Description

If the configuration is set as follows
```php
$options = [
  'host' => null, 
  'cluster' => null
]
```
Then, `array_key_exists` will only check if the key exists or not and will not check if the value is empty. If the keys exist and the value is `null`, then the URL generated will be `null` when `host` is null or `api-.pusher.com` when `cluster` is `null`. 

This causes an error in calling the URL of the pusher.

## CHANGELOG

* [ADDED] Check if the value of `host` and `cluster` in the options provided is null or not. If the keys exist on the options but the value is null, it falls back to the default value. 