### PR TITLE
Timeout option is not propagate to client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.2.4
+
+* [Fixed] set timeout in client
+
 ## 7.2.3
 
 * [Fixed] Include socket_id in batch trigger if included.

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -64,12 +64,6 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     {
         $this->check_compatibility();
 
-        if (!is_null($client)) {
-            $this->client = $client;
-        } else {
-            $this->client = new \GuzzleHttp\Client();
-        }
-
         $useTLS = true;
         if (isset($options['useTLS'])) {
             $useTLS = $options['useTLS'] === true;
@@ -118,6 +112,13 @@ class Pusher implements LoggerAwareInterface, PusherInterface
                 $options['encryption_master_key_base64']
             );
             $this->crypto = new PusherCrypto($parsedKey);
+        }
+
+
+        if (!is_null($client)) {
+            $this->client = $client;
+        } else {
+            $this->client = new \GuzzleHttp\Client(['timeout'  => $this->settings['timeout'],]);
         }
     }
 
@@ -724,7 +725,8 @@ class Pusher implements LoggerAwareInterface, PusherInterface
             'query' => $signature,
             'http_errors' => false,
             'headers' => $headers,
-            'base_uri' => $this->channels_url_prefix()
+            'base_uri' => $this->channels_url_prefix(),
+            'timeout' => $this->settings['timeout']
         ]);
 
         $status = $response->getStatusCode();
@@ -776,7 +778,8 @@ class Pusher implements LoggerAwareInterface, PusherInterface
                 'body' => $body,
                 'http_errors' => false,
                 'headers' => $headers,
-                'base_uri' => $this->channels_url_prefix()
+                'base_uri' => $this->channels_url_prefix(),
+                'timeout' => $this->settings['timeout']
             ]);
         } catch (ConnectException $e) {
             throw new ApiErrorException($e->getMessage());
@@ -826,7 +829,8 @@ class Pusher implements LoggerAwareInterface, PusherInterface
             'body' => $body,
             'http_errors' => false,
             'headers' => $headers,
-            'base_uri' => $this->channels_url_prefix()
+            'base_uri' => $this->channels_url_prefix(),
+            'timeout' => $this->settings['timeout'],
         ])->then(function ($response) {
             $status = $response->getStatusCode();
 

--- a/tests/unit/PusherConstructorTest.php
+++ b/tests/unit/PusherConstructorTest.php
@@ -22,8 +22,8 @@ class PusherConstructorTest extends TestCase
     {
         $options = [
             'useTLS' => true,
-            'host'   => 'test.com',
-            'port'   => '3000',
+            'host' => 'test.com',
+            'port' => '3000',
         ];
         $pusher = new Pusher('app_key', 'app_secret', 'app_id', $options);
 
@@ -60,11 +60,22 @@ class PusherConstructorTest extends TestCase
     {
         $options = [
             'cluster' => 'eu',
-            'host'    => 'api.staging.pusher.com',
+            'host' => 'api.staging.pusher.com',
         ];
         $pusher = new Pusher('app_key', 'app_secret', 'app_id', $options);
 
         $settings = $pusher->getSettings();
         self::assertEquals('api.staging.pusher.com', $settings['host']);
+    }
+
+    public function testSetTimeoutOption(): void
+    {
+        $options = [
+            'timeout' => 10,
+        ];
+        $pusher = new Pusher('app_key', 'app_secret', 'app_id', $options);
+
+        $settings = $pusher->getSettings();
+        self::assertEquals(10, $settings['timeout']);
     }
 }


### PR DESCRIPTION
## Description
Timeout option is not propagate to Guzzle client.
Fix https://github.com/pusher/pusher-http-php/issues/380

## CHANGELOG

* [Fixed] Timeout option is propagate to guzzle client
