### PR TITLE
Bump supported versions to include PHP8.2, 8.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} Test

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ then run `composer update`.
 
 ## Supported platforms
 
-* PHP - supports PHP versions 7.3, 7.4, 8.0, 8.1, and 8.2.
+* PHP - supports PHP versions 7.3, 7.4, 8.0, 8.1, 8.2, and 8.3.
 * Laravel - version 8.29 and above has built-in support for Pusher Channels as a [Broadcasting backend](https://laravel.com/docs/master/broadcasting).
 * Other PHP frameworks - supported provided you are using a supported version of PHP.
 
@@ -514,7 +514,7 @@ Requires [phpunit](https://github.com/sebastianbergmann/phpunit).
 
 * Run `composer install`
 * Go to the `tests` directory
-* Rename `config.example.php` and replace the values with valid Channels
+* Rename `config.example.php` to `config.php` and replace the values with valid Channels
   credentials **or** create environment variables.
 * Some tests require a client to be connected to the app you defined in the
   config; you can do this by opening

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ then run `composer update`.
 
 ## Supported platforms
 
-* PHP - supports PHP versions 7.3, 7.4, 8.0, and 8.1.
+* PHP - supports PHP versions 7.3, 7.4, 8.0, 8.1, and 8.2.
 * Laravel - version 8.29 and above has built-in support for Pusher Channels as a [Broadcasting backend](https://laravel.com/docs/master/broadcasting).
 * Other PHP frameworks - supported provided you are using a supported version of PHP.
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["php-pusher-server", "pusher", "rest", "realtime", "real-time", "real time", "messaging", "push", "trigger", "publish", "events"],
     "license": "MIT",
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.3|8.0|8.1|8.2",
         "ext-curl": "*",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["php-pusher-server", "pusher", "rest", "realtime", "real-time", "real time", "messaging", "push", "trigger", "publish", "events"],
     "license": "MIT",
     "require": {
-        "php": "^7.3|8.0|8.1|8.2",
+        "php": "^7.3|^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",


### PR DESCRIPTION
## Description

Adds PHP 8.2 and 8.3 to the CI test suite and README.

Updated the version constraint on PHP in Composer to explicitly list the supported PHP8 versions.

## CHANGELOG

* [CHANGED] Explicitly support PHP 8.2 and 8.3