### PR TITLE
Allow sodium_compat v1.6+ or v2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",
         "psr/log": "^1.0|^2.0|^3.0",
-        "paragonie/sodium_compat": "^1.6"
+        "paragonie/sodium_compat": "^1.6|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",


### PR DESCRIPTION
This is instead of https://github.com/pusher/pusher-http-php/pull/385 which was submitted 4 months ago, but not accepted after review.

This retains the minimum of 1.6, but also allow 2.x

More info: https://paragonie.com/blog/2024/04/release-sodium-compat-v2-and-future-our-polyfill-libraries