### PR TITLE
Upgrade actions/checkout@v2 to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           export NEW_VERSION=$(semver bump ${{ env.RELEASE }} $CURRENT)
           echo "VERSION=$NEW_VERSION" >> $GITHUB_ENV
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup git
         run: |
           git config user.email "pusher-ci@pusher.com"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -36,7 +36,7 @@ jobs:
       - name: Run unit tests
         run: composer exec phpunit tests/unit
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: pusher/public_actions
           path: .github/actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.2.5
+
+* [CHANGED] Describe your change here. Look at CHANGELOG.md to see the format.
+
 ## 7.2.4
 
 * [Fixed] Timeout option is propagated to guzzle client

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -19,7 +19,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     /**
      * @var string Version
      */
-    public static $VERSION = '7.2.4';
+    public static $VERSION = '7.2.5';
 
     /**
      * @var null|PusherCrypto


### PR DESCRIPTION
Seems like v2 is unable to checkout and find branches from forked repos which is breaking the release process. This discussion mentions upgrading as solution https://github.com/actions/checkout/issues/551 :crossed_fingers:

## Description

Add a short description of the change. If this is related to an issue, please add a reference to the issue.

## CHANGELOG

* [CHANGED] Describe your change here. Look at CHANGELOG.md to see the format.
