### PR TITLE
Fix type errors, incorrect docblocks

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -37,9 +37,9 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     ];
 
     /**
-     * @var null|resource
+     * @var null|ClientInterface Guzzle client
      */
-    private $client = null; // Guzzle client
+    private $client = null;
 
     /**
      * Initializes a new Pusher instance with key, secret, app ID and channel.
@@ -136,7 +136,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
      * Log a string.
      *
      * @param string           $msg     The message to log
-     * @param array|\Exception $context [optional] Any extraneous information that does not fit well in a string.
+     * @param array $context [optional] Any extraneous information that does not fit well in a string.
      * @param string           $level   [optional] Importance of log message, highly recommended to use Psr\Log\LogLevel::{level}
      */
     private function log(string $msg, array $context = [], string $level = LogLevel::DEBUG): void
@@ -1053,7 +1053,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     /**
      * Returns an event represented by an associative array to be used in creating events and batch_events requests
      *
-     * @param array|string $channels A channel name or an array of channel names to publish the event on.
+     * @param array $channels An array of channel names to publish the event on.
      * @param string $event
      * @param mixed $data Event data
      * @param array $params [optional]
@@ -1154,10 +1154,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     /**
      * Returns the body of a trigger batch events request serialized as string ready to be sent in a request
      *
-     * @param array|string $channels A channel name or an array of channel names to publish the event on.
-     * @param string $event
-     * @param mixed $data Event data
-     * @param array $params [optional]
+     * @param array $batch [optional]
      * @param bool $already_encoded [optional]
      *
      * @throws PusherException

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -996,7 +996,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
         try {
             $decoded_json = json_decode($body, false, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
-            $this->log('Unable to decrypt webhook event payload.', null, LogLevel::WARNING);
+            $this->log('Unable to decrypt webhook event payload.', [], LogLevel::WARNING);
             throw new PusherException('Data encoding error.');
         }
 
@@ -1006,12 +1006,12 @@ class Pusher implements LoggerAwareInterface, PusherInterface
                     $decryptedEvent = $this->crypto->decrypt_event($event);
 
                     if ($decryptedEvent === false) {
-                        $this->log('Unable to decrypt webhook event payload. Wrong key? Ignoring.', null, LogLevel::WARNING);
+                        $this->log('Unable to decrypt webhook event payload. Wrong key? Ignoring.', [], LogLevel::WARNING);
                         continue;
                     }
                     $decoded_events[] = $decryptedEvent;
                 } else {
-                    $this->log('Got an encrypted webhook event payload, but no master key specified. Ignoring.', null, LogLevel::WARNING);
+                    $this->log('Got an encrypted webhook event payload, but no master key specified. Ignoring.', [], LogLevel::WARNING);
                 }
             } else {
                 $decoded_events[] = $event;


### PR DESCRIPTION
## Description

Fixes some typing issues that Psalm caught. Calls to `Pusher::log()` with a disallowed `null` param, a docblock with the wrong method signatures, and several docblocks that have not been updated to match the now stricter types of their method signatures or class properties.

There should be no behavioral changes except that the `log` function calls will no longer trigger TypeErrors.

## CHANGELOG

* [FIXED] Correct Pusher.php docblock types to match method signatures/class properties
* [FIXED] Update the Pusher::webhook() method to no longer throw TypeErrors when logging