### PR TITLE
PHP 8.4 Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} Test

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -60,7 +60,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
      *
      * @throws PusherException Throws exception if any required dependencies are missing
      */
-    public function __construct(string $auth_key, string $secret, string $app_id, array $options = [], ClientInterface $client = null)
+    public function __construct(string $auth_key, string $secret, string $app_id, array $options = [], ?ClientInterface $client = null)
     {
         $this->check_compatibility();
 
@@ -287,7 +287,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
         string $request_path,
         array $query_params = [],
         string $auth_version = '1.0',
-        string $auth_timestamp = null
+        ?string $auth_timestamp = null
     ): array {
         $params = [];
         $params['auth_key'] = $auth_key;
@@ -884,7 +884,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
      * @return string Json encoded authentication string.
      * @throws PusherException Throws exception if $channel is invalid or above or $socket_id is invalid
      */
-    public function authorizeChannel(string $channel, string $socket_id, string $custom_data = null): string
+    public function authorizeChannel(string $channel, string $socket_id, ?string $custom_data = null): string
     {
         $this->validate_channel($channel);
         $this->validate_socket_id($socket_id);
@@ -949,7 +949,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     /**
      * @deprecated in favour of authorizeChannel
      */
-    public function socketAuth(string $channel, string $socket_id, string $custom_data = null): string
+    public function socketAuth(string $channel, string $socket_id, ?string $custom_data = null): string
     {
         return $this->authorizeChannel($channel, $socket_id, $custom_data);
     }
@@ -957,7 +957,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
     /**
      * @deprecated in favour of authorizeChannel
      */
-    public function socket_auth(string $channel, string $socket_id, string $custom_data = null): string
+    public function socket_auth(string $channel, string $socket_id, ?string $custom_data = null): string
     {
         return $this->authorizeChannel($channel, $socket_id, $custom_data);
     }

--- a/src/PusherInterface.php
+++ b/src/PusherInterface.php
@@ -130,7 +130,7 @@ interface PusherInterface
      * @return string Json encoded authentication string.
      * @throws PusherException Throws exception if $channel is invalid or above or $socket_id is invalid
      */
-    public function socketAuth(string $channel, string $socket_id, string $custom_data = null): string;
+    public function socketAuth(string $channel, string $socket_id, ?string $custom_data = null): string;
 
     /**
      * Creates a presence signature (an extension of socket signing).
@@ -229,7 +229,7 @@ interface PusherInterface
      * @return string Json encoded authentication string.
      * @throws PusherException Throws exception if $channel is invalid or above or $socket_id is invalid
      */
-    public function socket_auth(string $channel, string $socket_id, string $custom_data = null): string;
+    public function socket_auth(string $channel, string $socket_id, ?string $custom_data = null): string;
 
     /**
      * Creates a presence signature (an extension of socket signing).


### PR DESCRIPTION
## Description

Prevent PHP 8.4 deprecation for default null value without nullable type declaration.
Added PHP 8.4 to the test matrix

## CHANGELOG

* [CHANGED] Bump supported versions to include PHP 8.4
