### PR TITLE
fix: wrong pusher rest-api url

### DIFF
--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -701,7 +701,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
      * All request signing is handled automatically.
      *
      * @param string $path        Path excluding /apps/APP_ID
-     * @param array  $params      API params (see http://pusher.com/docs/rest_api)
+     * @param array  $params      API params (see http://pusher.com/docs/rest-api)
      * @param bool   $associative When true, return the response body as an associative array, else return as an object
      *
      * @throws ApiErrorException Throws ApiErrorException if the Channels HTTP API responds with an error


### PR DESCRIPTION
## Description

Old url says "Page not found", actual url is with -, not _

## CHANGELOG

* [FIXED] url to pusher rest-api documentation
