### PR TITLE
build(deps): Remove paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.2",
-        "psr/log": "^1.0|^2.0|^3.0",
-        "paragonie/sodium_compat": "^1.6|^2.0"
+        "psr/log": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",


### PR DESCRIPTION
Remove the redundant paragonie/sodium_compat dependency

Since this package requires PHP 7.3+, and libsodium has been available in PHP core since 7.2, the paragonie/sodium_compat polyfill is no longer needed. The sodium extension is already required by the code that uses sodium_crypto_secretbox functions.

This reduces the dependency tree and avoids installing unnecessary packages on modern PHP versions.

Fixes #400