### PR TITLE
Fix typed property syntax for PHP 7.3 compatibility in WebhookTest

### DIFF
--- a/tests/unit/WebhookTest.php
+++ b/tests/unit/WebhookTest.php
@@ -65,7 +65,7 @@ class WebhookTest extends TestCase
     public function testInvalidJsonBodyLogsWithArrayContext(): void
     {
         $logger = new class extends AbstractLogger {
-            public array $logs = [];
+            public $logs = [];
             public function log($level, $message, array $context = []): void
             {
                 $this->logs[] = ['level' => $level, 'message' => $message, 'context' => $context];
@@ -90,7 +90,7 @@ class WebhookTest extends TestCase
     public function testEncryptedEventWithNoMasterKeyLogsWithArrayContext(): void
     {
         $logger = new class extends AbstractLogger {
-            public array $logs = [];
+            public $logs = [];
             public function log($level, $message, array $context = []): void
             {
                 $this->logs[] = ['level' => $level, 'message' => $message, 'context' => $context];


### PR DESCRIPTION
The unit tests added in #404 used `public array $logs = []` in anonymous classes, which requires PHP 7.4+. PHP 7.3 is in the test matrix and fails with a syntax error on this line. Removes the type annotation to restore compatibility across all supported PHP versions.