### PR TITLE
Add support for Guzzle 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,11 @@
         "php": "^7.3|^8.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^7.2",
-        "psr/log": "^1.0|^2.0|^3.0"
+        "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
+        "guzzlehttp/psr7": "^2.6.3 || ^3.0",
+        "guzzlehttp/promises": "^2.0.3 || ^3.0",
+        "psr/http-client": "^1.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",

--- a/src/Pusher.php
+++ b/src/Pusher.php
@@ -3,8 +3,8 @@
 namespace Pusher;
 
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
@@ -721,7 +721,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
             'X-Pusher-Library' => 'pusher-http-php ' . self::$VERSION
         ];
 
-        $response = $this->client->get(ltrim($path, '/'), [
+        $response = $this->client->request('GET', ltrim($path, '/'), [
             'query' => $signature,
             'http_errors' => false,
             'headers' => $headers,
@@ -773,7 +773,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
         ];
 
         try {
-            $response = $this->client->post(ltrim($path, '/'), [
+            $response = $this->client->request('POST', ltrim($path, '/'), [
                 'query' => $params_with_signature,
                 'body' => $body,
                 'http_errors' => false,
@@ -781,8 +781,8 @@ class Pusher implements LoggerAwareInterface, PusherInterface
                 'base_uri' => $this->channels_url_prefix(),
                 'timeout' => $this->settings['timeout']
             ]);
-        } catch (ConnectException $e) {
-            throw new ApiErrorException($e->getMessage());
+        } catch (NetworkExceptionInterface $e) {
+            throw new ApiErrorException($e->getMessage(), 0, $e);
         }
 
         $status = $response->getStatusCode();
@@ -824,7 +824,7 @@ class Pusher implements LoggerAwareInterface, PusherInterface
             'X-Pusher-Library' => 'pusher-http-php ' . self::$VERSION
         ];
 
-        return $this->client->postAsync(ltrim($path, '/'), [
+        return $this->client->requestAsync('POST', ltrim($path, '/'), [
             'query' => $params_with_signature,
             'body' => $body,
             'http_errors' => false,
@@ -846,8 +846,16 @@ class Pusher implements LoggerAwareInterface, PusherInterface
             }
 
             return $response_body;
-        }, function (ConnectException $e) {
-            throw new ApiErrorException($e->getMessage());
+        }, function ($reason) {
+            if ($reason instanceof NetworkExceptionInterface) {
+                throw new ApiErrorException($reason->getMessage(), 0, $reason);
+            }
+
+            if ($reason instanceof \Throwable) {
+                throw $reason;
+            }
+
+            throw new PusherException('HTTP request failed.');
         });
     }
 

--- a/tests/unit/ChannelInfoUnitTest.php
+++ b/tests/unit/ChannelInfoUnitTest.php
@@ -2,8 +2,11 @@
 
 namespace unit;
 
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Pusher\Pusher;
+use stdClass;
 
 class ChannelInfoUnitTest extends TestCase
 {
@@ -43,5 +46,27 @@ class ChannelInfoUnitTest extends TestCase
         $this->expectException(\Pusher\PusherException::class);
 
         $this->pusher->get_channel_info('test_channel\n:');
+    }
+
+    public function testGetChannelInfoUsesClientInterfaceRequest(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+
+        $httpClient->expects(self::once())
+            ->method('request')
+            ->with(
+                'GET',
+                'apps/appid/channels/test_channel',
+                self::callback(function (array $options): bool {
+                    return $options['http_errors'] === false
+                        && $options['base_uri'] === 'https://api-test1.pusher.com:443'
+                        && $options['headers']['Content-Type'] === 'application/json';
+                })
+            )
+            ->willReturn(new Response(200, [], '{}'));
+
+        $pusher = new Pusher('auth-key', 'secret', 'appid', ['cluster' => 'test1'], $httpClient);
+
+        self::assertEquals(new stdClass(), $pusher->getChannelInfo('test_channel'));
     }
 }

--- a/tests/unit/TerminateUserConnectionsUnitTest.php
+++ b/tests/unit/TerminateUserConnectionsUnitTest.php
@@ -3,12 +3,19 @@
 namespace unit;
 
 use GuzzleHttp;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Exception\RequestException;
 use PHPUnit\Framework\TestCase;
 use Pusher\ApiErrorException;
 use Pusher\Pusher;
 use Pusher\PusherException;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Message\RequestInterface;
+use RuntimeException;
 use stdClass;
 
 class TerminateUserConnectionsUnitTest extends TestCase
@@ -75,5 +82,142 @@ class TerminateUserConnectionsUnitTest extends TestCase
         $pusher = $this->mockPusher([new Response(500, [], "{}")]);
         $this->expectException(ApiErrorException::class);
         $pusher->terminateUserConnectionsAsync("123")->wait();
+    }
+
+    public function testTerminateUserConnectionsUsesClientInterfaceRequest(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+
+        $httpClient->expects(self::once())
+            ->method('request')
+            ->with(
+                'POST',
+                'apps/appid/users/123/terminate_connections',
+                self::callback(function (array $options): bool {
+                    return $options['body'] === '{}'
+                        && $options['http_errors'] === false
+                        && $options['base_uri'] === 'https://api-test1.pusher.com:443'
+                        && $options['headers']['Content-Type'] === 'application/json';
+                })
+            )
+            ->willReturn(new Response(200, [], '{}'));
+
+        $pusher = new Pusher('auth-key', 'secret', 'appid', ['cluster' => 'test1'], $httpClient);
+
+        self::assertEquals(new stdClass(), $pusher->terminateUserConnections('123'));
+    }
+
+    public function testTerminateUserConnectionsAsyncUsesClientInterfaceRequestAsync(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+
+        $httpClient->expects(self::once())
+            ->method('requestAsync')
+            ->with(
+                'POST',
+                'apps/appid/users/123/terminate_connections',
+                self::callback(function (array $options): bool {
+                    return $options['body'] === '{}'
+                        && $options['http_errors'] === false
+                        && $options['base_uri'] === 'https://api-test1.pusher.com:443'
+                        && $options['headers']['Content-Type'] === 'application/json';
+                })
+            )
+            ->willReturn(new FulfilledPromise(new Response(200, [], '{}')));
+
+        $pusher = new Pusher('auth-key', 'secret', 'appid', ['cluster' => 'test1'], $httpClient);
+
+        self::assertEquals(new stdClass(), $pusher->terminateUserConnectionsAsync('123')->wait());
+    }
+
+    public function testTerminateUserConnectionsAsyncMapsNetworkExceptionToApiErrorException(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $networkException = new class ('connection failed', new Request('POST', 'https://example.com')) extends RuntimeException implements NetworkExceptionInterface {
+            private $request;
+
+            public function __construct(string $message, RequestInterface $request)
+            {
+                parent::__construct($message);
+                $this->request = $request;
+            }
+
+            public function getRequest(): RequestInterface
+            {
+                return $this->request;
+            }
+        };
+
+        $httpClient->method('requestAsync')
+            ->willReturn(new RejectedPromise($networkException));
+
+        $pusher = new Pusher('auth-key', 'secret', 'appid', ['cluster' => 'test1'], $httpClient);
+
+        try {
+            $pusher->terminateUserConnectionsAsync('123')->wait();
+            $this->fail('An exception should have been thrown.');
+        } catch (ApiErrorException $exception) {
+            self::assertSame('connection failed', $exception->getMessage());
+            self::assertSame($networkException, $exception->getPrevious());
+        }
+    }
+
+    public function testTerminateUserConnectionsAsyncMapsConnectExceptionToApiErrorException(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $connectException = new ConnectException(
+            'connection failed',
+            new Request('POST', 'https://example.com')
+        );
+
+        $httpClient->method('requestAsync')
+            ->willReturn(new RejectedPromise($connectException));
+
+        $pusher = new Pusher('auth-key', 'secret', 'appid', ['cluster' => 'test1'], $httpClient);
+
+        try {
+            $pusher->terminateUserConnectionsAsync('123')->wait();
+            $this->fail('An exception should have been thrown.');
+        } catch (ApiErrorException $exception) {
+            self::assertSame('connection failed', $exception->getMessage());
+            self::assertSame($connectException, $exception->getPrevious());
+        }
+    }
+
+    public function testTerminateUserConnectionsMapsConnectExceptionToApiErrorException(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $connectException = new ConnectException(
+            'connection failed',
+            new Request('POST', 'https://example.com')
+        );
+
+        $httpClient->method('request')
+            ->willThrowException($connectException);
+
+        $pusher = new Pusher('auth-key', 'secret', 'appid', ['cluster' => 'test1'], $httpClient);
+
+        try {
+            $pusher->terminateUserConnections('123');
+            $this->fail('An exception should have been thrown.');
+        } catch (ApiErrorException $exception) {
+            self::assertSame('connection failed', $exception->getMessage());
+            self::assertSame($connectException, $exception->getPrevious());
+        }
+    }
+
+    public function testTerminateUserConnectionsAsyncRethrowsNonConnectThrowable(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+
+        $httpClient->method('requestAsync')
+            ->willReturn(new RejectedPromise(new RuntimeException('boom')));
+
+        $pusher = new Pusher('auth-key', 'secret', 'appid', ['cluster' => 'test1'], $httpClient);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $pusher->terminateUserConnectionsAsync('123')->wait();
     }
 }


### PR DESCRIPTION
## Description

Add support for Guzzle 8, adds in missing dependencies you were explicitly using but forgot to add explicit dependencies on, and bound the minimum versions to avoid super old versions.

## CHANGELOG

* [CHANGED] Added support for Guzzle 8.

---

FYI, the Guzzle 8.0.0 release is tentatively planned for early Q3. I am sending this PR as part of both validating that key packages can upgrade to Guzzle 8, and to actually get them upgraded. This package was identified as a key ecosystem package either because it is a widely used package or because it is a dependency of Laravel. This PR is not suitable to merge until Guzzle 8.0.0's actually released.